### PR TITLE
Feature: Parameter annotations

### DIFF
--- a/src/main/php/lang/mirrors/Annotation.class.php
+++ b/src/main/php/lang/mirrors/Annotation.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\mirrors;
 
+use util\Objects;
+
 class Annotation extends \lang\Object {
   private $type, $name, $value;
 
@@ -14,4 +16,17 @@ class Annotation extends \lang\Object {
 
   /** @return var */
   public function value() { return $this->value ? $this->value->resolve($this->type->unit()) : null; }
+
+  /**
+   * Returns whether a given value is equal to this annotation
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && (
+      $this->name === $cmp->name &&
+      Objects::equal($this->value, $cmp->value)
+    );
+  }
 }

--- a/src/main/php/lang/mirrors/Annotation.class.php
+++ b/src/main/php/lang/mirrors/Annotation.class.php
@@ -3,10 +3,10 @@
 use util\Objects;
 
 class Annotation extends \lang\Object {
-  private $type, $name, $value;
+  private $mirror, $name, $value;
 
-  public function __construct(TypeMirror $type, $name, $value) {
-    $this->type= $type;
+  public function __construct(TypeMirror $mirror, $name, $value) {
+    $this->mirror= $mirror;
     $this->name= $name;
     $this->value= $value;
   }
@@ -15,7 +15,7 @@ class Annotation extends \lang\Object {
   public function name() { return $this->name; }
 
   /** @return var */
-  public function value() { return $this->value ? $this->value->resolve($this->type->unit()) : null; }
+  public function value() { return $this->value ? $this->value->resolve($this->mirror->unit()) : null; }
 
   /**
    * Returns whether a given value is equal to this annotation

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -45,7 +45,10 @@ abstract class Member extends \lang\Object {
   public function annotations() {
     $lookup= $this->mirror->unit()->declaration()[static::$kind];
     $name= $this->reflect->name;
-    return new Annotations($this->mirror, isset($lookup[$name]) ? (array)$lookup[$name]['annotations'] : []);
+    return new Annotations(
+      $this->mirror,
+      isset($lookup[$name]['annotations'][null]) ? (array)$lookup[$name]['annotations'][null] : []
+    );
   }
 
   /**

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -79,7 +79,13 @@ class Parameter extends \lang\Object {
 
   /** @return lang.mirrors.Annotations */
   public function annotations() {
-    $lookup= $this->mirror->declaredIn()->unit()->declaration()['method'][$this->mirror->reflect->name];
-    return new Annotations($this->mirror, (array)$lookup['annotations']);
+    $declared= $this->mirror->declaredIn();
+    $lookup= $declared->unit()->declaration()['method'];
+    $method= $this->mirror->reflect->name;
+    $name= '$'.$this->reflect->name;
+    return new Annotations(
+      $declared,
+      isset($lookup[$method]['annotations'][$name]) ? $lookup[$method]['annotations'][$name] : []
+    );
   }
 }

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -76,4 +76,10 @@ class Parameter extends \lang\Object {
     }
     throw new IllegalStateException('Parameter is not optional');
   }
+
+  /** @return lang.mirrors.Annotations */
+  public function annotations() {
+    $lookup= $this->mirror->declaredIn()->unit()->declaration()['method'][$this->mirror->reflect->name];
+    return new Annotations($this->mirror, (array)$lookup['annotations']);
+  }
 }

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -111,7 +111,8 @@ class TypeMirror extends \lang\Object {
 
   /** @return lang.mirrors.Annotations */
   public function annotations() {
-    return new Annotations($this, $this->unit()->declaration()['annotations']);
+    $lookup= $this->unit()->declaration()['annotations'];
+    return new Annotations($this, isset($lookup[null]) ? $lookup[null] : []);
   }
 
   /**

--- a/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
@@ -156,6 +156,14 @@ class AnnotationSyntaxTest extends \unittest\TestCase {
     );
   }
 
+  #[@test, @values(['$a', '$b'])]
+  public function two_target_annotations_without_values($name) {
+    $this->assertEquals(
+      ['test' => null],
+      $this->parse('[@$a: test, @$b: test]', $name)
+    );
+  }
+
   #[@test]
   public function target_annotation_with_key_value_pair() {
     $this->assertEquals(

--- a/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
@@ -20,13 +20,14 @@ class AnnotationSyntaxTest extends \unittest\TestCase {
    * Parses a string
    *
    * @param  string $input
+   * @param  string $target
    * @return var
    */
-  private function parse($input) {
+  private function parse($input, $target= null) {
     $unit= (new ClassSyntax())->parse(new StringInput(
       "<?php class Test {\n  $input\n  function fixture() { } }"
     ));
-    return $unit->declaration()['method']['fixture']['annotations'][null];
+    return $unit->declaration()['method']['fixture']['annotations'][$target];
   }
 
   #[@test]
@@ -144,6 +145,22 @@ class AnnotationSyntaxTest extends \unittest\TestCase {
     $this->assertEquals(
       ['test' => new Pairs($value)],
       $this->parse('[@test('.$literal.')]')
+    );
+  }
+
+  #[@test]
+  public function target_annotation_without_value() {
+    $this->assertEquals(
+      ['test' => null],
+      $this->parse('[@$param: test]', '$param')
+    );
+  }
+
+  #[@test]
+  public function target_annotation_with_key_value_pair() {
+    $this->assertEquals(
+      ['inject' => new Pairs(['name' => new Value('db')])],
+      $this->parse('[@$param: inject(name= "db")]', '$param')
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
@@ -26,7 +26,7 @@ class AnnotationSyntaxTest extends \unittest\TestCase {
     $unit= (new ClassSyntax())->parse(new StringInput(
       "<?php class Test {\n  $input\n  function fixture() { } }"
     ));
-    return $unit->declaration()['method']['fixture']['annotations'];
+    return $unit->declaration()['method']['fixture']['annotations'][null];
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\parse\ClassSyntax;
 use lang\mirrors\parse\CodeUnit;
+use lang\mirrors\parse\Value;
 
 /**
  * Tests ClassSyntax
@@ -46,12 +47,24 @@ class ClassSyntaxTest extends \unittest\TestCase {
             ]
           ],
           'method' => [
+            'connect' => [
+              'kind'        => 'method',
+              'name'        => 'connect',
+              'params'      => [[
+                'name'    => '$arg',
+                'type'    => null,
+                'ref'     => false,
+                'default' => null,
+              ]],
+              'access'      => ['private'],
+              'annotations' => ['$arg' => ['inject' => new Value('db')]]
+            ],
             'can_create' => [
               'kind'        => 'method',
               'name'        => 'can_create',
               'params'      => [],
               'access'      => ['public'],
-              'annotations' => ['test' => null]
+              'annotations' => [null => ['test' => null]]
             ]
           ]
         ]
@@ -62,6 +75,9 @@ class ClassSyntaxTest extends \unittest\TestCase {
 
         class IntegrationTest extends \unittest\TestCase {
           private $fixture;
+
+          #[@$arg: inject("db")]
+          private function connect($arg) { /* ... */ }
 
           #[@test]
           public function can_create() { /* ... */ }

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\Parameter;
 use lang\mirrors\Method;
+use lang\mirrors\Annotation;
 use lang\mirrors\TypeMirror;
 use lang\IllegalArgumentException;
 use lang\IllegalStateException;
@@ -34,7 +35,6 @@ class ParameterTest extends \unittest\TestCase {
   /** @param lang.Type */
   private function oneDocumentedTypeParam($arg) { }
 
-
   /**
    * Fixture
    *
@@ -42,6 +42,9 @@ class ParameterTest extends \unittest\TestCase {
    * @param lang.Type $b
    */
   private function twoDocumentedTypeParams($a, $b) { }
+
+  #[@$arg: test]
+  private function oneAnnotatedParam($arg) { }
 
   /**
    * Creates a new parameter
@@ -150,5 +153,19 @@ class ParameterTest extends \unittest\TestCase {
   #[@test]
   public function array_default_value_for_optional() {
     $this->assertEquals([1, 2, 3], $this->newFixture('oneArrayOptionalParam', 0)->defaultValue());
+  }
+
+  #[@test]
+  public function no_annotations() {
+    $this->assertFalse($this->newFixture('oneParam', 0)->annotations()->present());
+  }
+
+  #[@test]
+  public function annotated_parameter() {
+    $fixture= $this->newFixture('oneAnnotatedParam', 0);
+    $this->assertEquals(
+      [new Annotation(new TypeMirror(self::class), 'test', null)],
+      iterator_to_array($fixture->annotations())
+    );
   }
 }


### PR DESCRIPTION
This pull request adds support for parameter annotations as defined by xp-framework/rfc#218

```php
use rdbms\DBConnection;

class Example extends \lang\Object {

  #[@$conn: inject(name= 'db')[
  public function connect(DBConnection $conn)  {
    // ...
  }
}

$param= (new TypeMirror(Example::class))->methods()->named('connect')->parameters()->first();
$inject= $param->annotations()->named('inject');   // ["name" => "db"]
```