### PR TITLE
Reflection sources

### DIFF
--- a/src/main/php/lang/mirrors/Constants.class.php
+++ b/src/main/php/lang/mirrors/Constants.class.php
@@ -33,7 +33,7 @@ class Constants extends \lang\Object implements \IteratorAggregate {
    */
   public function named($name) {
     if ($this->provides($name)) {
-      return new Constant($this->mirror, $name, $this->mirror->reflect->getConstant($name));
+      return new Constant($this->mirror, $name, $this->mirror->reflect->constantNamed($name));
     }
     throw new ElementNotFoundException('No constant '.$name.' in '.$this->mirror->name());
   }
@@ -44,7 +44,7 @@ class Constants extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function getIterator() {
-    foreach ($this->mirror->reflect->getConstants() as $name => $value) {
+    foreach ($this->mirror->reflect->allConstants() as $name => $value) {
       yield new Constant($this->mirror, $name, $value);
     }
   }

--- a/src/main/php/lang/mirrors/Constructor.class.php
+++ b/src/main/php/lang/mirrors/Constructor.class.php
@@ -10,16 +10,6 @@ use lang\Throwable;
  * @test   xp://lang.mirrors.unittest.ConstructorTest
  */
 class Constructor extends Routine {
-  private static $DEFAULT;
-
-  static function __static() {
-    self::$DEFAULT= new \ReflectionMethod(self::class, '__default');
-  }
-
-  /** @return lang.Generic */
-  public function __default() {
-    return $this->reflect->newInstance();
-  }
 
   /**
    * Creates a new constructor
@@ -27,11 +17,11 @@ class Constructor extends Routine {
    * @param  lang.mirrors.TypeMirror $mirror
    */
   public function __construct($mirror) {
-    parent::__construct($mirror, $mirror->reflect->getConstructor() ?: self::$DEFAULT);
+    parent::__construct($mirror, $mirror->reflect->constructor());
   }
 
   /** @return bool */
-  public function present() { return self::$DEFAULT !== $this->reflect; }
+  public function present() { return '__default' !== $this->reflect['name']; }
 
   /**
    * Creates a new instance using this constructor
@@ -39,19 +29,7 @@ class Constructor extends Routine {
    * @param  var* $args
    * @return lang.Generic
    */
-  public function newInstance(... $args) {
-    if (!$this->mirror->reflect->isInstantiable()) {
-      throw new IllegalArgumentException('Verifying '.$this->mirror->name().': Cannot instantiate');
-    }
-
-    try {
-      return $this->mirror->reflect->newInstanceArgs($args);
-    } catch (Throwable $e) {
-      throw new TargetInvocationException('Creating a new instance of '.$this->mirror->name().' raised '.$e->getClassName(), $e);
-    } catch (\Exception $e) {
-      throw new IllegalArgumentException('Instantiating '.$this->mirror->name().': '.$e->getMessage());
-    }
-  }
+  public function newInstance(... $args) { return $this->mirror->reflect->newInstance($args); }
 
   /** @return string */
   public function __toString() {

--- a/src/main/php/lang/mirrors/Constructor.class.php
+++ b/src/main/php/lang/mirrors/Constructor.class.php
@@ -1,8 +1,5 @@
 <?php namespace lang\mirrors;
 
-use lang\IllegalArgumentException;
-use lang\Throwable;
-
 /**
  * Represents a constructor. If no constructor is present, a default 
  * no-arg constructor is used.

--- a/src/main/php/lang/mirrors/Field.class.php
+++ b/src/main/php/lang/mirrors/Field.class.php
@@ -21,17 +21,20 @@ class Field extends Member {
    * @throws lang.IllegalArgumentException If there is no such field
    */
   public function __construct($mirror, $arg) {
-    if ($arg instanceof \ReflectionProperty) {
+    if (is_array($arg)) {
       $reflect= $arg;
+    } else if ($arg instanceof \ReflectionProperty) {
+      $reflect= $arg;
+      $reflect->setAccessible(true);
     } else {
       try {
         $reflect= $mirror->reflect->getProperty($arg);
       } catch (\Exception $e) {
         throw new IllegalArgumentException('No field named $'.$arg.' in '.$mirror->name());
       }
+      $reflect->setAccessible(true);
     }
     parent::__construct($mirror, $reflect);
-    $reflect->setAccessible(true);
   }
 
   /**
@@ -58,6 +61,9 @@ class Field extends Member {
    * @throws lang.IllegalArgumentException
    */
   public function read(Generic $instance= null) {
+if (is_array($this->reflect)) {
+  return $this->mirror->reflect->readField($this->reflect['value'], $instance);
+}
     if ($this->reflect->isStatic()) {
       return $this->reflect->getValue(null);
     } else if ($instance && $this->reflect->getDeclaringClass()->isInstance($instance)) {
@@ -79,6 +85,9 @@ class Field extends Member {
    * @throws lang.IllegalArgumentException
    */
   public function modify(Generic $instance= null, $value) {
+if (is_array($this->reflect)) {
+  return $this->mirror->reflect->modifyField($this->reflect['value'], $instance, $value);
+}
     if ($this->reflect->isStatic()) {
       $this->reflect->setValue(null, $value);
       return;
@@ -95,6 +104,10 @@ class Field extends Member {
 
   /** @return string */
   public function __toString() {
+    try {
     return $this->modifiers()->names().' '.$this->type().' $'.$this->name();
+  } catch (\Exception $e) {
+    echo $e->getMessage();
+  }
   }
 }

--- a/src/main/php/lang/mirrors/Field.class.php
+++ b/src/main/php/lang/mirrors/Field.class.php
@@ -53,7 +53,7 @@ class Field extends Member {
    * @throws lang.IllegalArgumentException
    */
   public function read(Generic $instance= null) {
-    return $this->mirror->reflect->readField($this->reflect['value'], $instance);
+    return $this->reflect['read']($instance);
   }
 
   /**
@@ -65,7 +65,7 @@ class Field extends Member {
    * @throws lang.IllegalArgumentException
    */
   public function modify(Generic $instance= null, $value) {
-    return $this->mirror->reflect->modifyField($this->reflect['value'], $instance, $value);
+    return $this->reflect['modify']($instance, $value);
   }
 
   /** @return string */

--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -22,7 +22,7 @@ class Fields extends \lang\Object implements \IteratorAggregate {
    */
   public function provides($name) {
     if (0 === strncmp('__', $name, 2)) return false;
-    return $this->mirror->reflect->hasProperty($name);
+    return $this->mirror->reflect->hasField($name);
   }
 
   /**
@@ -70,8 +70,8 @@ class Fields extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function of($kind) {
-    foreach ($this->mirror->reflect->getProperties() as $field) {
-      if (0 === strncmp('__', $field->name, 2) || $kind === ($field->getModifiers() & MODIFIER_STATIC)) continue;
+    foreach ($this->mirror->reflect->allFields() as $name => $field) {
+      if (0 === strncmp('__', $name, 2) || $kind === ($field['access'] & MODIFIER_STATIC)) continue;
       yield new Field($this->mirror, $field);
     }
   }

--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -71,7 +71,7 @@ class Fields extends \lang\Object implements \IteratorAggregate {
    */
   public function of($kind) {
     foreach ($this->mirror->reflect->allFields() as $name => $field) {
-      if (0 === strncmp('__', $name, 2) || $kind === ($field['access'] & MODIFIER_STATIC)) continue;
+      if (0 === strncmp('__', $name, 2) || $kind === ($field['access']->isStatic())) continue;
       yield new Field($this->mirror, $field);
     }
   }

--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -34,7 +34,7 @@ class Fields extends \lang\Object implements \IteratorAggregate {
    */
   public function named($name) {
     if ($this->provides($name)) {
-      return new Field($this->mirror, $this->mirror->reflect->getProperty($name));
+      return new Field($this->mirror, $this->mirror->reflect->fieldNamed($name));
     }
     throw new ElementNotFoundException('No field $'.$name.' in '.$this->mirror->name());
   }
@@ -45,8 +45,8 @@ class Fields extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function getIterator() {
-    foreach ($this->mirror->reflect->getProperties() as $field) {
-      if (0 === strncmp('__', $field->name, 2)) continue;
+    foreach ($this->mirror->reflect->allFields() as $name => $field) {
+      if (0 === strncmp('__', $name, 2)) continue;
       yield new Field($this->mirror, $field);
     }
   }
@@ -57,8 +57,8 @@ class Fields extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function declared() {
-    foreach ($this->mirror->reflect->getProperties() as $field) {
-      if (0 === strncmp('__', $field->name, 2) || $field->getDeclaringClass()->name !== $this->mirror->reflect->name) continue;
+    foreach ($this->mirror->reflect->declaredFields() as $name => $field) {
+      if (0 === strncmp('__', $name, 2)) continue;
       yield new Field($this->mirror, $field);
     }
   }

--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -66,12 +66,17 @@ class Fields extends \lang\Object implements \IteratorAggregate {
   /**
    * Iterates over fields.
    *
-   * @param  int $kind Either Member::$STATIC or Member::$INSTANCE
+   * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
    * @return php.Generator
    */
   public function of($kind) {
-    foreach ($this->mirror->reflect->allFields() as $name => $field) {
-      if (0 === strncmp('__', $name, 2) || $kind === ($field['access']->isStatic())) continue;
+    $instance= ($kind & Member::$STATIC) === 0;
+    $fields= ($kind & Member::$DECLARED)
+      ? $this->mirror->reflect->declaredFields()
+      : $this->mirror->reflect->allFields()
+    ;
+    foreach ($fields as $name => $field) {
+      if (0 === strncmp('__', $name, 2) || $instance === $field['access']->isStatic()) continue;
       yield new Field($this->mirror, $field);
     }
   }

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -37,7 +37,7 @@ class FromCode extends \lang\Object implements Source {
    *
    * @param  bool $parent Whether to include parents
    * @param  bool $traits Whether to include traits
-   * @return [:var]
+   * @return php.Generator
    */
   private function declarations($parent, $traits) {
     yield $this->decl;
@@ -136,34 +136,32 @@ class FromCode extends \lang\Object implements Source {
 
   /** @return php.Generator */
   public function allInterfaces() {
-    $decl= $this->decl;
-    do {
-      foreach ($decl['implements'] as $interface) {
+    foreach ($this->declarations(true, false) as $decl) {
+      foreach ((array)$decl['implements'] as $interface) {
         $name= $this->resolve0($interface);
-        yield strtr($name, '.', '\\') => new self($name);
+        yield $name => new self($name);
       }
-    } while ($decl= $this->declarationOf($decl['parent']));
+    }
   }
 
   /** @return php.Generator */
   public function declaredInterfaces() {
     foreach ($this->decl['implements'] as $interface) {
       $name= $this->resolve0($interface);
-      yield strtr($name, '.', '\\') => new self($name);
+      yield $name => new self($name);
     }
   }
 
   /** @return php.Generator */
   public function allTraits() {
-    $decl= $this->decl;
-    do {
+    foreach ($this->declarations(true, false) as $decl) {
       if (!isset($decl['use'])) continue;
       foreach ($decl['use'] as $trait => $definition) {
         if ('\__xp' === $trait) continue;
         $name= $this->resolve0($trait);
         yield $name => new self($name);
       }
-    } while ($decl= $this->declarationOf($decl['parent']));
+    }
   }
 
   /** @return php.Generator */

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -66,6 +66,26 @@ class FromCode extends \lang\Object implements Source {
   /** @return bool */
   public function hasField($name) { return isset($this->decl['field']['$'.$name]); }
 
+  /** @return php.Generator */
+  public function allFields() {
+    $decl= $this->decl;
+    do {
+      foreach ($decl['field'] as $name => $field) {
+        yield substr($name, 1) => $field;
+      }
+
+      if (null === $decl['parent']) break;
+      $decl= (new ClassSyntax())->parse(new ClassSource($this->resolve0($decl['parent'])))->declaration();
+    } while ($decl);
+  }
+
+  /** @return php.Generator */
+  public function declaredFields() {
+    foreach ($this->decl['field'] as $name => $field) {
+      yield substr($name, 1) => $field;
+    }
+  }
+
   /** @return bool */
   public function hasConstant($name) { return isset($this->decl['const'][$name]); }
 

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -75,6 +75,33 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
+  /** @return [:var] */
+  public function constructor() {
+    $decl= $this->decl;
+    do {
+      if (isset($decl['method']['__construct'])) return $decl['method']['__construct'];
+    } while ($decl= $this->declarationOf($decl['parent']));
+
+    return [
+      'name'    => '__default',
+      'access'  => Modifiers::IS_PUBLIC,
+      'holder'  => $this->decl['name'],
+      'comment' => function() { return null; },
+      'params'  => function() { return []; },
+      'value'   => null
+    ];
+  }
+
+  /**
+   * Creates a new instance
+   *
+   * @param  var[] $args
+   * @return lang.Generic
+   */
+  public function newInstance($args) {
+    throw new IllegalArgumentException('Verifying '.$this->name.': Cannot instantiate');
+  }
+
   /** @return bool */
   public function hasField($name) {
     $decl= $this->decl;

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -29,6 +29,9 @@ class FromCode extends \lang\Object implements Source {
     return $parent ? new self($this->resolve($parent)) : null;
   }
 
+  /** @return var */
+  public function typeAnnotations() { return $this->decl['annotations']; }
+
   private function resolve($name) {
     if ('\\' === $name{0}) {
       return strtr(substr($name, 1), '\\', '.');

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -6,6 +6,7 @@ use lang\mirrors\parse\ClassSource;
 class FromCode extends \lang\Object implements Source {
   private $unit, $decl;
   private static $syntax;
+  public $name;
 
   static function __static() {
     self::$syntax= new ClassSyntax();
@@ -14,6 +15,7 @@ class FromCode extends \lang\Object implements Source {
   public function __construct($name) {
     $this->unit= self::$syntax->parse(new ClassSource(strtr($name, '\\', '.')));
     $this->decl= $this->unit->declaration();
+    $this->name= $this->decl['name'];
   }
 
   /**

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -11,6 +11,10 @@ class FromCode extends \lang\Object implements Source {
     $this->decl= $this->unit->declaration();
   }
 
+  public function codeUnit() {
+    return $this->unit;
+  }
+
   /** @return string */
   public function typeName() { 
     $package= $this->unit->package();
@@ -38,6 +42,19 @@ class FromCode extends \lang\Object implements Source {
       return new Modifiers(Modifiers::IS_PUBLIC | Modifiers::IS_ABSTRACT);
     } else {
       return new Modifiers(array_merge(['public'], $this->decl['modifiers']));
+    }
+  }
+
+  /** @return lang.mirrors.Kind */
+  public function typeKind() {
+    if ('trait' === $this->decl['kind']) {
+      return Kind::$TRAIT;
+    } else if ('interface' === $this->decl['kind']) {
+      return Kind::$INTERFACE;
+    } else if ('lang.Enum' === $this->resolve($this->decl['parent'])) {
+      return Kind::$ENUM;
+    } else {
+      return Kind::$CLASS;
     }
   }
 

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -4,27 +4,28 @@ use lang\mirrors\parse\ClassSyntax;
 use lang\mirrors\parse\ClassSource;
 
 class FromCode extends \lang\Object implements Source {
-  private $unit;
+  private $unit, $decl;
 
   public function __construct($name) {
     $this->unit= (new ClassSyntax())->parse(new ClassSource(strtr($name, '\\', '.')));
+    $this->decl= $this->unit->declaration();
   }
 
   /** @return string */
   public function typeName() { 
     $package= $this->unit->package();
-    return ($package ? $package.'.' : '').$this->unit->declaration()['name'];
+    return ($package ? $package.'.' : '').$this->decl['name'];
   }
 
   /** @return string */
-  public function typeDeclaration() { return $this->unit->declaration()['name']; }
+  public function typeDeclaration() { return $this->decl['name']; }
 
   /** @return string */
   public function packageName() { return $this->unit->package(); }
 
   /** @return string */
   public function typeParent() {
-    $parent= $this->unit->declaration()['parent'];
+    $parent= $this->decl['parent'];
     return $parent ? new self($this->resolve($parent)) : null;
   }
 

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -237,6 +237,49 @@ class FromCode extends \lang\Object implements Source {
   public function hasConstant($name) { return isset($this->decl['const'][$name]); }
 
   /**
+   * Gets a constant by its name
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function constantNamed($name) {
+    $decl= $this->decl;
+    do {
+      if (isset($decl['const'][$name])) return $decl['const'][$name]['value']->resolve($this->mirror);
+    } while ($decl= $this->declarationOf($decl['parent']));
+    return null;
+  }
+
+  /** @return php.Generator */
+  public function allConstants() {
+    $decl= $this->decl;
+    do {
+      if (!isset($decl['const'])) continue;
+      foreach ($decl['const'] as $name => $const) {
+        yield $name => $const['value']->resolve($this->mirror);
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+  }
+
+  /**
+   * Returns whether this type is a subtype of a given argument
+   *
+   * @param  string $class
+   * @return bool
+   */
+  public function isSubtypeOf($class) {
+    $decl= $this->decl;
+    $class= strtr($class, '\\', '.');
+    do {
+      if ($class === $this->resolve0($decl['parent'])) return true;
+      foreach ((array)$decl['implements'] as $interface) {
+        if ($class === $this->resolve0($interface)) return true;
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+    return false;
+  }
+
+  /**
    * Resolves a type name in the context of this reflection source
    *
    * @param  string $name

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\mirrors;
+
+use lang\mirrors\parse\ClassSyntax;
+use lang\mirrors\parse\ClassSource;
+
+class FromCode extends \lang\Object implements Source {
+  private $unit;
+
+  public function __construct($name) {
+    $this->unit= (new ClassSyntax())->parse(new ClassSource(strtr($name, '\\', '.')));
+  }
+
+  /** @return string */
+  public function typeName() { 
+    $package= $this->unit->package();
+    return ($package ? $package.'.' : '').$this->unit->declaration()['name'];
+  }
+}

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -32,6 +32,11 @@ class FromCode extends \lang\Object implements Source {
   /** @return var */
   public function typeAnnotations() { return $this->decl['annotations']; }
 
+  /** @return lang.mirrors.Modifiers */
+  public function typeModifiers() {
+    return new Modifiers(array_merge(['public'], $this->decl['modifiers']));
+  }
+
   private function resolve($name) {
     if ('\\' === $name{0}) {
       return strtr(substr($name, 1), '\\', '.');

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -20,6 +20,9 @@ class FromCode extends \lang\Object implements Source {
   public function typeDeclaration() { return $this->unit->declaration()['name']; }
 
   /** @return string */
+  public function packageName() { return $this->unit->package(); }
+
+  /** @return string */
   public function typeParent() {
     $parent= $this->unit->declaration()['parent'];
     return $parent ? new self($this->resolve($parent)) : null;

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -15,11 +15,12 @@ class FromCode extends \lang\Object implements Source {
     self::$syntax= new ClassSyntax();
   }
 
-  public function __construct($name) {
+  public function __construct($name, Sources $source= null) {
     $this->unit= self::$syntax->codeUnitOf($name);
     $this->decl= $this->unit->declaration();
     $package= $this->unit->package();
     $this->name= ($package ? $package.'\\' : '').$this->decl['name'];
+    $this->source= $source ?: Sources::$CODE;
   }
 
   /**
@@ -139,7 +140,7 @@ class FromCode extends \lang\Object implements Source {
     foreach ($this->declarations(true, false) as $decl) {
       foreach ((array)$decl['implements'] as $interface) {
         $name= $this->resolve0($interface);
-        yield $name => new self($name);
+        yield $name => $this->source->reflect($name);
       }
     }
   }
@@ -148,7 +149,7 @@ class FromCode extends \lang\Object implements Source {
   public function declaredInterfaces() {
     foreach ($this->decl['implements'] as $interface) {
       $name= $this->resolve0($interface);
-      yield $name => new self($name);
+      yield $name => $this->source->reflect($name);
     }
   }
 
@@ -159,7 +160,7 @@ class FromCode extends \lang\Object implements Source {
       foreach ($decl['use'] as $trait => $definition) {
         if ('\__xp' === $trait) continue;
         $name= $this->resolve0($trait);
-        yield $name => new self($name);
+        yield $name => $this->source->reflect($name);
       }
     }
   }
@@ -170,7 +171,7 @@ class FromCode extends \lang\Object implements Source {
     foreach ($this->decl['use'] as $trait => $definition) {
       if ('\__xp' === $trait) continue;
       $name= $this->resolve0($trait);
-      yield $name => new self($name);
+      yield $name => $this->source->reflect($name);
     }
   }
 
@@ -431,7 +432,7 @@ class FromCode extends \lang\Object implements Source {
    * @return self
    */
   public function resolve($name) {
-    return new self($this->resolve0($name));
+    return $this->source->reflect($this->resolve0($name));
   }
 
   /**

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -60,6 +60,15 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
+  /** @return bool */
+  public function hasMethod($name) { return isset($this->decl['method'][$name]); }
+
+  /** @return bool */
+  public function hasField($name) { return isset($this->decl['field']['$'.$name]); }
+
+  /** @return bool */
+  public function hasConstant($name) { return isset($this->decl['const'][$name]); }
+
   /**
    * Resolves a type name in the context of this reflection source
    *

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -77,6 +77,36 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
+  /** @return php.Generator */
+  public function allInterfaces() {
+    $decl= $this->decl;
+    do {
+      foreach ($decl['implements'] as $interface) {
+        $name= $this->resolve0($interface);
+        yield strtr($name, '.', '\\') => new self($name);
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+  }
+
+  /** @return php.Generator */
+  public function declaredInterfaces() {
+    foreach ($this->decl['implements'] as $interface) {
+      $name= $this->resolve0($interface);
+      yield strtr($name, '.', '\\') => new self($name);
+    }
+  }
+
+  public function typeImplements($name) {
+    $decl= $this->decl;
+    $name= strtr($name, '\\', '.');
+    do {
+      foreach ($decl['implements'] as $interface) {
+        if ($name === $this->resolve0($interface)) return true;
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+    return false;
+  }
+
   /** @return [:var] */
   public function constructor() {
     $decl= $this->decl;

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -15,7 +15,8 @@ class FromCode extends \lang\Object implements Source {
   public function __construct($name) {
     $this->unit= self::$syntax->parse(new ClassSource(strtr($name, '\\', '.')));
     $this->decl= $this->unit->declaration();
-    $this->name= $this->decl['name'];
+    $package= $this->unit->package();
+    $this->name= ($package ? strtr($package, '.', '\\').'\\' : '').$this->decl['name'];
   }
 
   /**
@@ -32,10 +33,7 @@ class FromCode extends \lang\Object implements Source {
   public function codeUnit() { return $this->unit; }
 
   /** @return string */
-  public function typeName() { 
-    $package= $this->unit->package();
-    return ($package ? $package.'.' : '').$this->decl['name'];
-  }
+  public function typeName() { return strtr($this->name, '\\', '.'); }
 
   /** @return string */
   public function typeDeclaration() { return $this->decl['name']; }

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -5,7 +5,7 @@ use lang\mirrors\parse\ClassSource;
 
 class FromCode extends \lang\Object implements Source {
   private $unit, $decl;
-  private static $syntax;
+  private static $syntax, $cache;
   public $name;
 
   static function __static() {
@@ -13,20 +13,10 @@ class FromCode extends \lang\Object implements Source {
   }
 
   public function __construct($name) {
-    $this->unit= $this->parse($name);
+    $this->unit= self::$syntax->codeUnitOf($name);
     $this->decl= $this->unit->declaration();
     $package= $this->unit->package();
     $this->name= ($package ? $package.'\\' : '').$this->decl['name'];
-  }
-
-  /**
-   * Parses class into a code unit
-   *
-   * @param  string $class Fully qualified class name
-   * @return lang.mirrors.parse.CodeUnit
-   */
-  private function parse($class) {
-    return self::$syntax->parse(new ClassSource(strtr($class, '\\', '.')));
   }
 
   /**
@@ -36,7 +26,7 @@ class FromCode extends \lang\Object implements Source {
    * @return [:var]
    */
   private function declarationOf($name) {
-    return $name ? $this->parse($this->resolve0($name))->declaration() : null;
+    return $name ? self::$syntax->codeUnitOf($this->resolve0($name))->declaration() : null;
   }
 
   /** @return lang.mirrors.parse.CodeUnit */

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -274,8 +274,10 @@ class FromCode extends \lang\Object implements Source {
 
   /** @return php.Generator */
   public function allFields() {
-    foreach ($this->decl['field'] as $name => $field) {
-      yield $name => $this->field($this->decl['name'], $field);
+    if (isset($this->decl['field'])) {
+      foreach ($this->decl['field'] as $name => $field) {
+        yield $name => $this->field($this->decl['name'], $field);
+      }
     }
     foreach ($this->merge(true, true) as $reflect) {
       foreach ($reflect->allFields() as $name => $field) {
@@ -287,8 +289,10 @@ class FromCode extends \lang\Object implements Source {
 
   /** @return php.Generator */
   public function declaredFields() {
-    foreach ($this->decl['field'] as $name => $field) {
-      yield $name => $this->field($this->decl['name'], $field);
+    if (isset($this->decl['field'])) {
+      foreach ($this->decl['field'] as $name => $field) {
+        yield $name => $this->field($this->decl['name'], $field);
+      }
     }
     foreach ($this->merge(false, true) as $reflect) {
       foreach ($reflect->allFields() as $name => $field) {
@@ -393,8 +397,10 @@ class FromCode extends \lang\Object implements Source {
 
   /** @return php.Generator */
   public function allMethods() {
-    foreach ($this->decl['method'] as $name => $method) {
-      yield $name => $this->method($this->decl['name'], $method);
+    if (isset($this->decl['method'])) {
+      foreach ($this->decl['method'] as $name => $method) {
+        yield $name => $this->method($this->decl['name'], $method);
+      }
     }
     foreach ($this->merge(true, true) as $reflect) {
       foreach ($reflect->allMethods() as $name => $method) {
@@ -406,8 +412,10 @@ class FromCode extends \lang\Object implements Source {
 
   /** @return php.Generator */
   public function declaredMethods() {
-    foreach ($this->decl['method'] as $name => $method) {
-      yield $name => $this->method($this->decl['name'], $method);
+    if (isset($this->decl['method'])) {
+      foreach ($this->decl['method'] as $name => $method) {
+        yield $name => $this->method($this->decl['name'], $method);
+      }
     }
     foreach ($this->merge(false, true) as $reflect) {
       foreach ($reflect->allMethods() as $name => $method) {

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -34,7 +34,11 @@ class FromCode extends \lang\Object implements Source {
 
   /** @return lang.mirrors.Modifiers */
   public function typeModifiers() {
-    return new Modifiers(array_merge(['public'], $this->decl['modifiers']));
+    if ('trait' === $this->decl['kind']) {
+      return new Modifiers(Modifiers::IS_PUBLIC | Modifiers::IS_ABSTRACT);
+    } else {
+      return new Modifiers(array_merge(['public'], $this->decl['modifiers']));
+    }
   }
 
   private function resolve($name) {

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -107,6 +107,41 @@ class FromCode extends \lang\Object implements Source {
     return false;
   }
 
+  /** @return php.Generator */
+  public function allTraits() {
+    $decl= $this->decl;
+    do {
+      if (!isset($decl['use'])) continue;
+      foreach ($decl['use'] as $trait => $definition) {
+        if ('\__xp' === $trait) continue;
+        $name= $this->resolve0($trait);
+        yield strtr($name, '.', '\\') => new self($name);
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+  }
+
+  /** @return php.Generator */
+  public function declaredTraits() {
+    if (!isset($this->decl['use'])) return;
+    foreach ($this->decl['use'] as $trait => $definition) {
+      if ('\__xp' === $trait) continue;
+      $name= $this->resolve0($trait);
+      yield strtr($name, '.', '\\') => new self($name);
+    }
+  }
+
+  public function typeUses($name) {
+    $decl= $this->decl;
+    $name= strtr($name, '\\', '.');
+    do {
+      if (!isset($decl['use'])) continue;
+      foreach ($decl['use'] as $trait => $definition) {
+        if ($name === $this->resolve0($trait)) return true;
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+    return false;
+  }
+
   /** @return [:var] */
   public function constructor() {
     $decl= $this->decl;

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -98,7 +98,7 @@ class FromCode extends \lang\Object implements Source {
    * Returns whether this type implements a given interface
    *
    * @param  string $name
-   * @param  bool
+   * @return bool
    */
   public function typeImplements($name) {
     $decl= $this->decl;
@@ -156,7 +156,7 @@ class FromCode extends \lang\Object implements Source {
    * Returns whether this type uses a given trait
    *
    * @param  string $name
-   * @param  bool
+   * @return bool
    */
   public function typeUses($name) {
     $decl= $this->decl;

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -77,6 +77,39 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
+  /**
+   * Returns whether this type is a subtype of a given argument
+   *
+   * @param  string $class
+   * @return bool
+   */
+  public function isSubtypeOf($class) {
+    $decl= $this->decl;
+    do {
+      if ($class === $this->resolve0($decl['parent'])) return true;
+      foreach ((array)$decl['implements'] as $interface) {
+        if ($class === $this->resolve0($interface)) return true;
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+    return false;
+  }
+
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @param  bool
+   */
+  public function typeImplements($name) {
+    $decl= $this->decl;
+    do {
+      foreach ($decl['implements'] as $interface) {
+        if ($name === $this->resolve0($interface)) return true;
+      }
+    } while ($decl= $this->declarationOf($decl['parent']));
+    return false;
+  }
+
   /** @return php.Generator */
   public function allInterfaces() {
     $decl= $this->decl;
@@ -94,22 +127,6 @@ class FromCode extends \lang\Object implements Source {
       $name= $this->resolve0($interface);
       yield strtr($name, '.', '\\') => new self($name);
     }
-  }
-
-  /**
-   * Returns whether this type implements a given interface
-   *
-   * @param  string $name
-   * @param  bool
-   */
-  public function typeImplements($name) {
-    $decl= $this->decl;
-    do {
-      foreach ($decl['implements'] as $interface) {
-        if ($name === $this->resolve0($interface)) return true;
-      }
-    } while ($decl= $this->declarationOf($decl['parent']));
-    return false;
   }
 
   /** @return php.Generator */
@@ -355,23 +372,6 @@ class FromCode extends \lang\Object implements Source {
   }
 
   /**
-   * Returns whether this type is a subtype of a given argument
-   *
-   * @param  string $class
-   * @return bool
-   */
-  public function isSubtypeOf($class) {
-    $decl= $this->decl;
-    do {
-      if ($class === $this->resolve0($decl['parent'])) return true;
-      foreach ((array)$decl['implements'] as $interface) {
-        if ($class === $this->resolve0($interface)) return true;
-      }
-    } while ($decl= $this->declarationOf($decl['parent']));
-    return false;
-  }
-
-  /**
    * Resolves a type name in the context of this reflection source
    *
    * @param  string $name
@@ -405,7 +405,13 @@ class FromCode extends \lang\Object implements Source {
     return new self($this->resolve0($name));
   }
 
+  /**
+   * Returns whether a given value is equal to this reflection source
+   *
+   * @param  var $cmp
+   * @return bool
+   */
   public function equals($cmp) {
-    return $cmp instanceof self && $this->typeName() === $cmp->typeName();
+    return $cmp instanceof self && $this->name === $cmp->name;
   }
 }

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -41,7 +41,7 @@ class FromCode extends \lang\Object implements Source {
   /** @return string */
   public function packageName() { return strtr($this->unit->package(), '\\', '.'); }
 
-  /** @return string */
+  /** @return self */
   public function typeParent() {
     $parent= $this->decl['parent'];
     return $parent ? $this->resolve($parent) : null;
@@ -94,6 +94,12 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @param  bool
+   */
   public function typeImplements($name) {
     $decl= $this->decl;
     do {
@@ -127,6 +133,12 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
+  /**
+   * Returns whether this type uses a given trait
+   *
+   * @param  string $name
+   * @param  bool
+   */
   public function typeUses($name) {
     $decl= $this->decl;
     do {
@@ -165,7 +177,12 @@ class FromCode extends \lang\Object implements Source {
     throw new IllegalArgumentException('Verifying '.$this->name.': Cannot instantiate');
   }
 
-  /** @return bool */
+  /**
+   * Checks whether a given field exists
+   *
+   * @param  string $name
+   * @return bool
+   */
   public function hasField($name) {
     $decl= $this->decl;
     do {
@@ -174,7 +191,12 @@ class FromCode extends \lang\Object implements Source {
     return false;
   }
 
-  /** @return [:var] */
+  /**
+   * Gets a field by its name
+   *
+   * @param  string $name
+   * @return var
+   */
   public function fieldNamed($name) {
     $decl= $this->decl;
     do {
@@ -200,10 +222,20 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
-  /** @return bool */
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $name
+   * @return bool
+   */
   public function hasMethod($name) { return isset($this->decl['method'][$name]); }
 
-  /** @return [:var] */
+  /**
+   * Gets a method by its name
+   *
+   * @param  string $name
+   * @return var
+   */
   public function methodNamed($name) {
     $decl= $this->decl;
     do {
@@ -229,7 +261,12 @@ class FromCode extends \lang\Object implements Source {
     }
   }
 
-  /** @return bool */
+  /**
+   * Checks whether a given constant exists
+   *
+   * @param  string $name
+   * @return bool
+   */
   public function hasConstant($name) { return isset($this->decl['const'][$name]); }
 
   /**

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -37,7 +37,6 @@ class FromCode extends \lang\Object implements Source {
 
     if ($traits && isset($this->decl['use'])) {
       foreach ($this->decl['use'] as $trait => $definition) {
-        if ('\__xp' === $trait) continue;
         yield $this->resolve($trait);
       }
     }
@@ -125,7 +124,6 @@ class FromCode extends \lang\Object implements Source {
   /** @return php.Generator */
   public function allInterfaces() {
     foreach ($this->decl['implements'] as $interface) {
-      if ('\__xp' === $interface) continue;
       $name= $this->resolve0($interface);
       yield $name => $this->source->reflect($name);
     }
@@ -139,7 +137,6 @@ class FromCode extends \lang\Object implements Source {
   /** @return php.Generator */
   public function declaredInterfaces() {
     foreach ($this->decl['implements'] as $interface) {
-      if ('\__xp' === $interface) continue;
       $name= $this->resolve0($interface);
       yield $name => $this->source->reflect($name);
     }
@@ -149,7 +146,6 @@ class FromCode extends \lang\Object implements Source {
   public function allTraits() {
     if (isset($this->decl['use'])) {
       foreach ($this->decl['use'] as $trait => $definition) {
-        if ('\__xp' === $trait) continue;
         $name= $this->resolve0($trait);
         yield $name => $this->source->reflect($name);
       }
@@ -165,7 +161,6 @@ class FromCode extends \lang\Object implements Source {
   public function declaredTraits() {
     if (isset($this->decl['use'])) {
       foreach ($this->decl['use'] as $trait => $definition) {
-        if ('\__xp' === $trait) continue;
         $name= $this->resolve0($trait);
         yield $name => $this->source->reflect($name);
       }
@@ -181,7 +176,6 @@ class FromCode extends \lang\Object implements Source {
   public function typeUses($name) {
     if (isset($this->decl['use'])) {
       foreach ($this->decl['use'] as $trait => $definition) {
-        if ('\__xp' === $trait) continue;
         if ($name === $this->resolve0($trait)) return true;
       }
     }

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -15,4 +15,24 @@ class FromCode extends \lang\Object implements Source {
     $package= $this->unit->package();
     return ($package ? $package.'.' : '').$this->unit->declaration()['name'];
   }
+
+  /** @return string */
+  public function typeDeclaration() { return $this->unit->declaration()['name']; }
+
+  /** @return string */
+  public function typeParent() {
+    $parent= $this->unit->declaration()['parent'];
+    return $parent ? new self($this->resolve($parent)) : null;
+  }
+
+  private function resolve($name) {
+    if ('\\' === $name{0}) {
+      return strtr(substr($name, 1), '\\', '.');
+    }
+    throw new \lang\MethodNotImplementedException($name);
+  }
+
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->typeName() === $cmp->typeName();
+  }
 }

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -205,8 +205,7 @@ class FromCode extends \lang\Object implements Source {
       'access'  => Modifiers::IS_PUBLIC,
       'holder'  => $this->decl['name'],
       'comment' => function() { return null; },
-      'params'  => function() { return []; },
-      'value'   => null
+      'params'  => function() { return []; }
     ];
   }
 
@@ -232,8 +231,7 @@ class FromCode extends \lang\Object implements Source {
       'name'    => $field['name'],
       'access'  => new Modifiers($field['access']),
       'holder'  => $holder,
-      'comment' => function() use($field) { return $field['comment']; },
-      'value'   => null
+      'comment' => function() use($field) { return $field['comment']; }
     ];
   }
 
@@ -355,8 +353,7 @@ class FromCode extends \lang\Object implements Source {
         }
         return $params;
       },
-      'comment' => function() use($method) { return $method['comment']; },
-      'value'   => null
+      'comment' => function() use($method) { return $method['comment']; }
     ];
   }
 

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -4,6 +4,7 @@ use lang\mirrors\parse\ClassSyntax;
 use lang\mirrors\parse\ClassSource;
 use lang\Type;
 use lang\XPClass;
+use lang\ElementNotFoundException;
 
 class FromCode extends \lang\Object implements Source {
   private static $syntax;
@@ -215,13 +216,15 @@ class FromCode extends \lang\Object implements Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function fieldNamed($name) {
     $decl= $this->decl;
     do {
       if (isset($decl['field'][$name])) return $decl['field'][$name];
     } while ($decl= $this->declarationOf($decl['parent']));
-    return null;
+
+    throw new ElementNotFoundException('No field named $'.$name.' in '.$this->name);
   }
 
   /** @return php.Generator */
@@ -312,13 +315,15 @@ class FromCode extends \lang\Object implements Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function methodNamed($name) {
     $decl= $this->decl;
     do {
       if (isset($decl['method'][$name])) return $this->method($decl['name'], $decl['method'][$name]);
     } while ($decl= $this->declarationOf($decl['parent']));
-    return null;
+
+    throw new ElementNotFoundException('No method named '.$name.' in '.$this->name);
   }
 
   /** @return php.Generator */
@@ -351,13 +356,15 @@ class FromCode extends \lang\Object implements Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function constantNamed($name) {
     $decl= $this->decl;
     do {
       if (isset($decl['const'][$name])) return $decl['const'][$name]['value']->resolve($this->mirror);
     } while ($decl= $this->declarationOf($decl['parent']));
-    return null;
+
+    throw new ElementNotFoundException('No constant named '.$name.' in '.$this->name);
   }
 
   /** @return php.Generator */

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -221,6 +221,23 @@ class FromCode extends \lang\Object implements Source {
   }
 
   /**
+   * Maps a field
+   *
+   * @param  string $holder
+   * @param  [:var] $field
+   * @return [:var]
+   */
+  private function field($holder, $field) {
+    return [
+      'name'    => $field['name'],
+      'access'  => new Modifiers($field['access']),
+      'holder'  => $holder,
+      'comment' => function() use($field) { return $field['comment']; },
+      'value'   => null
+    ];
+  }
+
+  /**
    * Checks whether a given field exists
    *
    * @param  string $name
@@ -245,7 +262,7 @@ class FromCode extends \lang\Object implements Source {
    * @throws lang.ElementNotFoundException
    */
   public function fieldNamed($name) {
-    if (isset($this->decl['field'][$name])) return $this->decl['field'][$name];
+    if (isset($this->decl['field'][$name])) return $this->field($this->decl['name'], $this->decl['field'][$name]);
     foreach ($this->merge(true, true) as $reflect) {
       foreach ($reflect->allFields() as $cmp => $field) {
         if ($cmp === $name) return $field;
@@ -258,7 +275,7 @@ class FromCode extends \lang\Object implements Source {
   /** @return php.Generator */
   public function allFields() {
     foreach ($this->decl['field'] as $name => $field) {
-      yield $name => $field;
+      yield $name => $this->field($this->decl['name'], $field);
     }
     foreach ($this->merge(true, true) as $reflect) {
       foreach ($reflect->allFields() as $name => $field) {
@@ -271,7 +288,7 @@ class FromCode extends \lang\Object implements Source {
   /** @return php.Generator */
   public function declaredFields() {
     foreach ($this->decl['field'] as $name => $field) {
-      yield $name => $field;
+      yield $name => $this->field($this->decl['name'], $field);
     }
     foreach ($this->merge(false, true) as $reflect) {
       foreach ($reflect->allFields() as $name => $field) {
@@ -325,7 +342,7 @@ class FromCode extends \lang\Object implements Source {
   private function method($holder, $method) {
     return [
       'name'    => $method['name'],
-      'access'  => $method['access'],
+      'access'  => new Modifiers($method['access']),
       'holder'  => $holder,
       'params'  => function() use($method) {
         $params= [];

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -4,8 +4,8 @@ use lang\mirrors\parse\ClassSyntax;
 use lang\mirrors\parse\ClassSource;
 
 class FromCode extends \lang\Object implements Source {
+  private static $syntax;
   private $unit, $decl;
-  private static $syntax, $cache;
   public $name;
 
   static function __static() {

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -33,6 +33,9 @@ class FromCode extends \lang\Object implements Source {
     return $parent ? new self($this->resolve($parent)) : null;
   }
 
+  /** @return string */
+  public function typeComment() { return $this->decl['comment']; }
+
   /** @return var */
   public function typeAnnotations() { return $this->decl['annotations']; }
 

--- a/src/main/php/lang/mirrors/FromIncomplete.class.php
+++ b/src/main/php/lang/mirrors/FromIncomplete.class.php
@@ -21,14 +21,14 @@ class FromIncomplete extends \lang\Object implements Source {
 
   /** @return string */
   public function typeDeclaration() {
-    $sep= strrpos($this->name, '\\');
-    return false === $ns ? $this->name : substr($this->name, 0, $sep + 1);
+    $ns= strrpos($this->name, '\\');
+    return false === $ns ? $this->name : substr($this->name, $ns + 1);
   }
 
   /** @return string */
   public function packageName() {
-    $sep= strrpos($this->name, '\\');
-    return false === $ns ? $this->name : substr($this->name, $sep + 1);
+    $ns= strrpos($this->name, '\\');
+    return false === $ns ? null : substr($this->name, 0, $ns);
   }
 
   /** @return self */

--- a/src/main/php/lang/mirrors/FromIncomplete.class.php
+++ b/src/main/php/lang/mirrors/FromIncomplete.class.php
@@ -63,16 +63,16 @@ class FromIncomplete extends \lang\Object implements Source {
   public function typeImplements($name) { return false; }
 
   /** @return php.Generator */
-  public function allInterfaces() { yield; }
+  public function allInterfaces() { return []; }
 
   /** @return php.Generator */
-  public function declaredInterfaces() { yield; }
+  public function declaredInterfaces() { return []; }
 
   /** @return php.Generator */
-  public function allTraits() { yield; }
+  public function allTraits() { return []; }
 
   /** @return php.Generator */
-  public function declaredTraits() { yield; }
+  public function declaredTraits() { return []; }
 
   /**
    * Returns whether this type uses a given trait
@@ -124,10 +124,10 @@ class FromIncomplete extends \lang\Object implements Source {
   }
 
   /** @return php.Generator */
-  public function allFields() { yield; }
+  public function allFields() { return []; }
 
   /** @return php.Generator */
-  public function declaredFields() { yield; }
+  public function declaredFields() { return []; }
 
   /**
    * Checks whether a given method exists
@@ -149,10 +149,10 @@ class FromIncomplete extends \lang\Object implements Source {
   }
 
   /** @return php.Generator */
-  public function allMethods() { yield; }
+  public function allMethods() { return []; }
 
   /** @return php.Generator */
-  public function declaredMethods() { yield; }
+  public function declaredMethods() { return []; }
 
   /**
    * Checks whether a given constant exists
@@ -174,7 +174,7 @@ class FromIncomplete extends \lang\Object implements Source {
   }
 
   /** @return php.Generator */
-  public function allConstants() { yield; }
+  public function allConstants() { return []; }
 
   /**
    * Resolves a type name in the context of this reflection source

--- a/src/main/php/lang/mirrors/FromIncomplete.class.php
+++ b/src/main/php/lang/mirrors/FromIncomplete.class.php
@@ -1,0 +1,198 @@
+<?php namespace lang\mirrors;
+
+use lang\mirrors\parse\ClassSyntax;
+use lang\mirrors\parse\ClassSource;
+use lang\Type;
+use lang\XPClass;
+use lang\ElementNotFoundException;
+
+class FromIncomplete extends \lang\Object implements Source {
+  public $name;
+
+  public function __construct($name) {
+    $this->name= $name;
+  }
+
+  /** @return lang.mirrors.parse.CodeUnit */
+  public function codeUnit() { return null; }
+
+  /** @return string */
+  public function typeName() { return strtr($this->name, '\\', '.'); }
+
+  /** @return string */
+  public function typeDeclaration() {
+    $sep= strrpos($this->name, '\\');
+    return false === $ns ? $this->name : substr($this->name, 0, $sep + 1);
+  }
+
+  /** @return string */
+  public function packageName() {
+    $sep= strrpos($this->name, '\\');
+    return false === $ns ? $this->name : substr($this->name, $sep + 1);
+  }
+
+  /** @return self */
+  public function typeParent() { return null; }
+
+  /** @return string */
+  public function typeComment() { return null; }
+
+  /** @return var */
+  public function typeAnnotations() { return []; }
+
+  /** @return lang.mirrors.Modifiers */
+  public function typeModifiers() { return new Modifiers(Modifiers::IS_PUBLIC); }
+
+  /** @return lang.mirrors.Kind */
+  public function typeKind() { return Kind::$CLASS; }
+
+  /**
+   * Returns whether this type is a subtype of a given argument
+   *
+   * @param  string $class
+   * @return bool
+   */
+  public function isSubtypeOf($class) { return false; }
+
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function typeImplements($name) { return false; }
+
+  /** @return php.Generator */
+  public function allInterfaces() { yield; }
+
+  /** @return php.Generator */
+  public function declaredInterfaces() { yield; }
+
+  /** @return php.Generator */
+  public function allTraits() { yield; }
+
+  /** @return php.Generator */
+  public function declaredTraits() { yield; }
+
+  /**
+   * Returns whether this type uses a given trait
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function typeUses($name) { return false; }
+
+  /** @return [:var] */
+  public function constructor() {
+    return [
+      'name'    => '__default',
+      'access'  => Modifiers::IS_PUBLIC,
+      'holder'  => $this->name,
+      'comment' => function() { return null; },
+      'params'  => function() { return []; },
+      'value'   => null
+    ];
+  }
+
+  /**
+   * Creates a new instance
+   *
+   * @param  var[] $args
+   * @return lang.Generic
+   */
+  public function newInstance($args) {
+    throw new IllegalArgumentException('Cannot instantiate incomplete type '.$this->name);
+  }
+
+  /**
+   * Checks whether a given field exists
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function hasField($name) { return false; }
+
+  /**
+   * Gets a field by its name
+   *
+   * @param  string $name
+   * @return var
+   * @throws lang.ElementNotFoundException
+   */
+  public function fieldNamed($name) {
+    throw new ElementNotFoundException('No field named $'.$name.' in '.$this->name);
+  }
+
+  /** @return php.Generator */
+  public function allFields() { yield; }
+
+  /** @return php.Generator */
+  public function declaredFields() { yield; }
+
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function hasMethod($name) { return false; }
+
+  /**
+   * Gets a method by its name
+   *
+   * @param  string $name
+   * @return var
+   * @throws lang.ElementNotFoundException
+   */
+  public function methodNamed($name) {
+    throw new ElementNotFoundException('No method named '.$name.' in '.$this->name);
+  }
+
+  /** @return php.Generator */
+  public function allMethods() { yield; }
+
+  /** @return php.Generator */
+  public function declaredMethods() { yield; }
+
+  /**
+   * Checks whether a given constant exists
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function hasConstant($name) { return false; }
+
+  /**
+   * Gets a constant by its name
+   *
+   * @param  string $name
+   * @return var
+   * @throws lang.ElementNotFoundException
+   */
+  public function constantNamed($name) {
+    throw new ElementNotFoundException('No constant named '.$name.' in '.$this->name);
+  }
+
+  /** @return php.Generator */
+  public function allConstants() { yield; }
+
+  /**
+   * Resolves a type name in the context of this reflection source
+   *
+   * @param  string $name
+   * @return self
+   */
+  public function resolve($name) {
+    return $name;
+  }
+
+  /**
+   * Returns whether a given value is equal to this reflection source
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->name === $cmp->name;
+  }
+}

--- a/src/main/php/lang/mirrors/FromIncomplete.class.php
+++ b/src/main/php/lang/mirrors/FromIncomplete.class.php
@@ -89,8 +89,7 @@ class FromIncomplete extends \lang\Object implements Source {
       'access'  => Modifiers::IS_PUBLIC,
       'holder'  => $this->name,
       'comment' => function() { return null; },
-      'params'  => function() { return []; },
-      'value'   => null
+      'params'  => function() { return []; }
     ];
   }
 

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -209,7 +209,7 @@ class FromReflection extends \lang\Object implements Source {
     $reflect->setAccessible(true);
     return [
       'name'    => $reflect->name,
-      'access'  => $reflect->getModifiers() & ~0x1fb7f008,
+      'access'  => new Modifiers($reflect->getModifiers() & ~0x1fb7f008),
       'holder'  => $reflect->getDeclaringClass()->name,
       'comment' => function() use($reflect) { return $reflect->getDocComment(); },
       'value'   => $reflect
@@ -325,7 +325,7 @@ class FromReflection extends \lang\Object implements Source {
     $reflect->setAccessible(true);
     return [
       'name'    => $reflect->name,
-      'access'  => $reflect->getModifiers() & ~0x1fb7f008,
+      'access'  => new Modifiers($reflect->getModifiers() & ~0x1fb7f008),
       'holder'  => $reflect->getDeclaringClass()->name,
       'params'  => function() use($reflect) {
         $params= [];

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -5,6 +5,7 @@ use lang\mirrors\parse\ClassSource;
 use lang\XPClass;
 use lang\Type;
 use lang\Enum;
+use lang\ElementNotFoundException;
 use lang\IllegalArgumentException;
 use lang\Throwable;
 
@@ -252,12 +253,13 @@ class FromReflection extends \lang\Object implements Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function fieldNamed($name) {
     try {
       return $this->field($this->reflect->getProperty($name));
     } catch (\Exception $e) {
-      throw new IllegalArgumentException('No field named $'.$name.' in '.$this->name);
+      throw new ElementNotFoundException('No field named $'.$name.' in '.$this->name);
     }
   }
 
@@ -362,12 +364,13 @@ class FromReflection extends \lang\Object implements Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function methodNamed($name) { 
     try {
       return $this->method($this->reflect->getMethod($name));
     } catch (\Exception $e) {
-      throw new IllegalArgumentException('No method named '.$name.'() in '.$this->name);
+      throw new ElementNotFoundException('No method named '.$name.'() in '.$this->name);
     }
   }
 
@@ -399,13 +402,13 @@ class FromReflection extends \lang\Object implements Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function constantNamed($name) {
-    try {
+    if ($this->reflect->hasConstant($name)) {
       return $this->reflect->getConstant($name);
-    } catch (\Exception $e) {
-      throw new IllegalArgumentException('No constant named $'.$name.' in '.$this->name);
     }
+    throw new ElementNotFoundException('No constant named '.$name.'() in '.$this->name);
   }
 
   /** @return php.Generator */

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -19,7 +19,7 @@ class FromReflection extends \lang\Object implements Source {
   /** @return lang.mirrors.parse.CodeUnit */
   public function codeUnit() {
     if (null === $this->unit) {
-      $this->unit= (new ClassSyntax())->parse(new ClassSource($this->typeName()));
+      $this->unit= (new ClassSyntax())->codeUnitOf($this->name);
     }
     return $this->unit;
   }

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -39,6 +39,23 @@ class FromReflection extends \lang\Object implements Source {
     return $this->unit()->declaration()['annotations'];
   }
 
+  /** @return lang.mirrors.Modifiers */
+  public function typeModifiers() {
+
+    // HHVM and PHP differ in this. We'll handle traits as *always* abstract (needs
+    // to be implemented) and *never* final (couldn't be implemented otherwise).
+    if ($this->reflect->isTrait()) {
+      return new Modifiers(Modifiers::IS_PUBLIC | Modifiers::IS_ABSTRACT);
+    } else {
+      $r= Modifiers::IS_PUBLIC;
+      $m= $this->reflect->getModifiers();
+      $m & \ReflectionClass::IS_EXPLICIT_ABSTRACT && $r |= Modifiers::IS_ABSTRACT;
+      $m & \ReflectionClass::IS_IMPLICIT_ABSTRACT && $r |= Modifiers::IS_ABSTRACT;
+      $m & \ReflectionClass::IS_FINAL && $r |= Modifiers::IS_FINAL;
+      return new Modifiers($r);
+    }
+  }
+
   public function __call($name, $args) {
     return $this->reflect->{$name}(...$args);
   }

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -15,10 +15,14 @@ class FromReflection extends \lang\Object implements Source {
   /** @return string */
   public function typeDeclaration() { return $this->reflect->getShortName(); }
 
+  /** @return string */
+  public function packageName() { return strtr($this->reflect->getNamespaceName(), '\\', '.'); }
+
   public function typeParent() {
     $parent= $this->reflect->getParentClass();
     return $parent ? new self($parent) : null;
   }
+
 
   public function __call($name, $args) {
     return $this->reflect->{$name}(...$args);

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -78,6 +78,15 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
+  /** @return bool */
+  public function hasMethod($name) { return $this->reflect->hasMethod($name); }
+
+  /** @return bool */
+  public function hasField($name) { return $this->reflect->hasProperty($name); }
+
+  /** @return bool */
+  public function hasConstant($name) { return $this->reflect->hasConstant($name); }
+
   /**
    * Resolves a type name in the context of this reflection source
    *

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -171,7 +171,13 @@ class FromReflection extends \lang\Object implements Source {
   }
 
   /** @return [:var] */
-  public function fieldNamed($name) { return $this->field($this->reflect->getProperty($name)); }
+  public function fieldNamed($name) {
+    try {
+      return $this->field($this->reflect->getProperty($name));
+    } catch (\Exception $e) {
+      throw new IllegalArgumentException('No field named $'.$name.' in '.$this->name);
+    }
+  }
 
   /** @return php.Generator */
   public function allFields() {
@@ -205,7 +211,13 @@ class FromReflection extends \lang\Object implements Source {
   }
 
   /** @return [:var] */
-  public function methodNamed($name) { return $this->method($this->reflect->getMethod($name)); }
+  public function methodNamed($name) { 
+    try {
+      return $this->method($this->reflect->getMethod($name));
+    } catch (\Exception $e) {
+      throw new IllegalArgumentException('No method named '.$name.'() in '.$this->name);
+    }
+  }
 
   /**
    * Maps a method

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -101,6 +101,33 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
+  /** @return php.Generator */
+  public function allTraits() {
+    $reflect= $this->reflect;
+    do {
+      foreach ($reflect->getTraits() as $trait) {
+        if ('__xp' === $trait->name) continue;
+        yield $trait->name => new self($trait);
+      }
+    } while ($reflect= $reflect->getParentClass());
+  }
+
+  /** @return php.Generator */
+  public function declaredTraits() {
+    foreach ($this->reflect->getTraits() as $trait) {
+      if ('__xp' === $trait->name) continue;
+      yield $trait->name => new self($trait);
+    }
+  }
+
+  public function typeUses($name) {
+    $reflect= $this->reflect;
+    do {
+      if (in_array($name, $reflect->getTraitNames(), true)) return true;
+    } while ($reflect= $reflect->getParentClass());
+    return false;
+  }
+
   /** @return [:var] */
   public function constructor() {
     $ctor= $this->reflect->getConstructor();

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -96,7 +96,7 @@ class FromReflection extends \lang\Object implements Source {
    * Returns whether this type implements a given interface
    *
    * @param  string $name
-   * @param  bool
+   * @return  bool
    */
   public function typeImplements($name) {
     return $this->reflect->implementsInterface($name);
@@ -142,7 +142,7 @@ class FromReflection extends \lang\Object implements Source {
    * Returns whether this type implements a given interface
    *
    * @param  string $name
-   * @param  bool
+   * @return bool
    */
   public function typeUses($name) {
     $reflect= $this->reflect;

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -38,7 +38,8 @@ class FromReflection extends \lang\Object implements Source {
 
   /** @return string */
   public function typeComment() {
-    return $this->reflect->getDocComment();
+    $comment= $this->reflect->getDocComment();
+    return false === $comment ? null : $comment;
   }
 
   /** @return var */

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -126,7 +126,6 @@ class FromReflection extends \lang\Object implements Source {
     $reflect= $this->reflect;
     do {
       foreach ($reflect->getTraits() as $trait) {
-        if ('__xp' === $trait->name) continue;
         yield $trait->name => $this->source->reflect($trait);
       }
     } while ($reflect= $reflect->getParentClass());
@@ -135,7 +134,6 @@ class FromReflection extends \lang\Object implements Source {
   /** @return php.Generator */
   public function declaredTraits() {
     foreach ($this->reflect->getTraits() as $trait) {
-      if ('__xp' === $trait->name) continue;
       yield $trait->name => $this->source->reflect($trait);
     }
   }

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -10,16 +10,6 @@ class FromReflection extends \lang\Object implements Source {
   private $reflect;
   private $unit= null;
   public $name;
-  private static $DEFAULT;
-
-  static function __static() {
-    self::$DEFAULT= new \ReflectionMethod(self::class, '__default');
-  }
-
-  /** @return lang.Generic */
-  public function __default() {
-    return $this->reflect->newInstance();
-  }
 
   public function __construct(\ReflectionClass $reflect) {
     $this->reflect= $reflect;
@@ -100,7 +90,7 @@ class FromReflection extends \lang\Object implements Source {
         'holder'  => $this->reflect->name,
         'comment' => function() { return null; },
         'params'  => function() { return []; },
-        'value'   => self::$DEFAULT
+        'value'   => null
       ];
     } else {
       return $this->method($ctor);

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -304,6 +304,37 @@ class FromReflection extends \lang\Object implements Source {
   public function hasConstant($name) { return $this->reflect->hasConstant($name); }
 
   /**
+   * Gets a constant by its name
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function constantNamed($name) {
+    try {
+      return $this->reflect->getConstant($name);
+    } catch (\Exception $e) {
+      throw new IllegalArgumentException('No constant named $'.$name.' in '.$this->name);
+    }
+  }
+
+  /** @return php.Generator */
+  public function allConstants() {
+    foreach ($this->reflect->getConstants() as $name => $value) {
+      yield $name => $value;
+    }
+  }
+
+  /**
+   * Returns whether this type is a subtype of a given argument
+   *
+   * @param  string $class
+   * @return bool
+   */
+  public function isSubtypeOf($class) {
+    return $this->reflect->isSubclassOf($class);
+  }
+
+  /**
    * Resolves a type name in the context of this reflection source
    *
    * @param  string $name
@@ -324,10 +355,6 @@ class FromReflection extends \lang\Object implements Source {
       }
       return new self(new \ReflectionClass($this->reflect->getNamespaceName().'\\'.$name));
     }
-  }
-
-  public function __call($name, $args) {
-    return $this->reflect->{$name}(...$args);
   }
 
   public function equals($cmp) {

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -325,16 +325,6 @@ class FromReflection extends \lang\Object implements Source {
   }
 
   /**
-   * Returns whether this type is a subtype of a given argument
-   *
-   * @param  string $class
-   * @return bool
-   */
-  public function isSubtypeOf($class) {
-    return $this->reflect->isSubclassOf($class);
-  }
-
-  /**
    * Resolves a type name in the context of this reflection source
    *
    * @param  string $name
@@ -351,10 +341,21 @@ class FromReflection extends \lang\Object implements Source {
       return new self(new \ReflectionClass(strtr($name, '.', '\\')));
     } else {
       foreach ($this->codeUnit()->imports() as $imported) {
-        if (0 === substr_compare($imported, $name, strrpos($imported, '.') + 1)) return new self(new \ReflectionClass(strtr($imported, '.', '\\')));
+        if (0 === substr_compare($imported, $name, strrpos($imported, '\\') + 1)) return new self(new \ReflectionClass($imported));
       }
-      return new self(new \ReflectionClass($this->reflect->getNamespaceName().'\\'.$name));
+      $ns= $this->reflect->getNamespaceName();
+      return new self(new \ReflectionClass(($ns ? $ns.'\\' : '').$name));
     }
+  }
+
+  /**
+   * Returns whether this type is a subtype of a given argument
+   *
+   * @param  string $class
+   * @return bool
+   */
+  public function isSubtypeOf($class) {
+    return $this->reflect->isSubclassOf($class);
   }
 
   public function equals($cmp) {

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -205,7 +205,6 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   private function field($reflect) {
-    $reflect->setAccessible(true);
     return [
       'name'    => $reflect->name,
       'access'  => new Modifiers($reflect->getModifiers() & ~0x1fb7f008),
@@ -224,11 +223,13 @@ class FromReflection extends \lang\Object implements Source {
    * @return var
    */
   private function readField($reflect, $instance) {
+    $reflect->setAccessible(true);
     if ($reflect->isStatic()) {
       return $reflect->getValue(null);
     } else if ($instance && $reflect->getDeclaringClass()->isInstance($instance)) {
       return $reflect->getValue($instance);
     }
+
     throw new IllegalArgumentException(sprintf(
       'Verifying %s(): Object passed is not an instance of the class declaring this field',
       $reflect->name
@@ -244,6 +245,7 @@ class FromReflection extends \lang\Object implements Source {
    * @return voud
    */
   private function modifyField($reflect, $instance, $value) {
+    $reflect->setAccessible(true);
     if ($reflect->isStatic()) {
       $reflect->setValue(null, $value);
       return;
@@ -331,7 +333,6 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   private function method($reflect) {
-    $reflect->setAccessible(true);
     return [
       'name'    => $reflect->name,
       'access'  => new Modifiers($reflect->getModifiers() & ~0x1fb7f008),
@@ -365,6 +366,7 @@ class FromReflection extends \lang\Object implements Source {
    * @return var
    */
   private function invokeMethod($reflect, $instance, $args) {
+    $reflect->setAccessible(true);
     try {
       return $reflect->invokeArgs($instance, $args);
     } catch (Throwable $e) {

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -23,7 +23,7 @@ class FromReflection extends \lang\Object implements Source {
   /** @return lang.mirrors.parse.CodeUnit */
   public function codeUnit() {
     if (null === $this->unit) {
-      $this->unit= (new ClassSyntax())->codeUnitOf($this->name);
+      $this->unit= (new ClassSyntax())->codeUnitOf($this->typeName());
     }
     return $this->unit;
   }

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -36,6 +36,11 @@ class FromReflection extends \lang\Object implements Source {
     return $parent ? new self($parent) : null;
   }
 
+  /** @return string */
+  public function typeComment() {
+    return $this->reflect->getDocComment();
+  }
+
   /** @return var */
   public function typeAnnotations() {
     return $this->codeUnit()->declaration()['annotations'];

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -1,0 +1,22 @@
+<?php namespace lang\mirrors;
+
+class FromReflection extends \lang\Object implements Source {
+  private $reflect;
+  public $name;
+
+  public function __construct(\ReflectionClass $reflect) {
+    $this->reflect= $reflect;
+    $this->name= $reflect->getName();
+  }
+
+  public function typeName() { return strtr($this->name, '\\', '.'); }
+
+  public function typeParent() {
+    $parent= $this->reflect->getParentClass();
+    return $parent ? new self($parent) : null;
+  }
+
+  public function __call($name, $args) {
+    return $this->reflect->{$name}(...$args);
+  }
+}

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -1,7 +1,11 @@
 <?php namespace lang\mirrors;
 
+use lang\mirrors\parse\ClassSyntax;
+use lang\mirrors\parse\ClassSource;
+
 class FromReflection extends \lang\Object implements Source {
   private $reflect;
+  private $unit= null;
   public $name;
 
   public function __construct(\ReflectionClass $reflect) {
@@ -23,6 +27,17 @@ class FromReflection extends \lang\Object implements Source {
     return $parent ? new self($parent) : null;
   }
 
+  public function unit() {
+    if (null === $this->unit) {
+      $this->unit= (new ClassSyntax())->parse(new ClassSource($this->typeName()));
+    }
+    return $this->unit;
+  }
+
+  /** @return var */
+  public function typeAnnotations() {
+    return $this->unit()->declaration()['annotations'];
+  }
 
   public function __call($name, $args) {
     return $this->reflect->{$name}(...$args);

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -9,7 +9,11 @@ class FromReflection extends \lang\Object implements Source {
     $this->name= $reflect->getName();
   }
 
+  /** @return string */
   public function typeName() { return strtr($this->name, '\\', '.'); }
+
+  /** @return string */
+  public function typeDeclaration() { return $this->reflect->getShortName(); }
 
   public function typeParent() {
     $parent= $this->reflect->getParentClass();
@@ -18,5 +22,9 @@ class FromReflection extends \lang\Object implements Source {
 
   public function __call($name, $args) {
     return $this->reflect->{$name}(...$args);
+  }
+
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->name === $cmp->name;
   }
 }

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -80,6 +80,12 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @param  bool
+   */
   public function typeImplements($name) {
     return $this->reflect->implementsInterface($name);
   }
@@ -120,6 +126,12 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @param  bool
+   */
   public function typeUses($name) {
     $reflect= $this->reflect;
     do {
@@ -165,7 +177,12 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
-  /** @return bool */
+  /**
+   * Checks whether a given field exists
+   *
+   * @param  string $name
+   * @return bool
+   */
   public function hasField($name) { return $this->reflect->hasProperty($name); }
 
   /**
@@ -218,7 +235,12 @@ class FromReflection extends \lang\Object implements Source {
     ));
   }
 
-  /** @return [:var] */
+  /**
+   * Gets a field by its name
+   *
+   * @param  string $name
+   * @return var
+   */
   public function fieldNamed($name) {
     try {
       return $this->field($this->reflect->getProperty($name));
@@ -242,7 +264,12 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
-  /** @return bool */
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $name
+   * @return bool
+   */
   public function hasMethod($name) { return $this->reflect->hasMethod($name); }
 
   /**
@@ -258,7 +285,12 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
-  /** @return [:var] */
+  /**
+   * Gets a method by its name
+   *
+   * @param  string $name
+   * @return var
+   */
   public function methodNamed($name) { 
     try {
       return $this->method($this->reflect->getMethod($name));
@@ -300,7 +332,12 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
-  /** @return bool */
+  /**
+   * Checks whether a given constant exists
+   *
+   * @param  string $name
+   * @return bool
+   */
   public function hasConstant($name) { return $this->reflect->hasConstant($name); }
 
   /**

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -50,19 +50,6 @@ class FromReflection extends \lang\Object implements Source {
     return $this->codeUnit()->declaration()['annotations'];
   }
 
-  /** @return lang.mirrors.Kind */
-  public function typeKind() {
-    if ($this->reflect->isTrait()) {
-      return Kind::$TRAIT;
-    } else if ($this->reflect->isInterface()) {
-      return Kind::$INTERFACE;
-    } else if ($this->reflect->isSubclassOf(Enum::class)) {
-      return Kind::$ENUM;
-    } else {
-      return Kind::$CLASS;
-    }
-  }
-
   /** @return lang.mirrors.Modifiers */
   public function typeModifiers() {
 
@@ -77,6 +64,40 @@ class FromReflection extends \lang\Object implements Source {
       $m & \ReflectionClass::IS_IMPLICIT_ABSTRACT && $r |= Modifiers::IS_ABSTRACT;
       $m & \ReflectionClass::IS_FINAL && $r |= Modifiers::IS_FINAL;
       return new Modifiers($r);
+    }
+  }
+
+  /** @return lang.mirrors.Kind */
+  public function typeKind() {
+    if ($this->reflect->isTrait()) {
+      return Kind::$TRAIT;
+    } else if ($this->reflect->isInterface()) {
+      return Kind::$INTERFACE;
+    } else if ($this->reflect->isSubclassOf(Enum::class)) {
+      return Kind::$ENUM;
+    } else {
+      return Kind::$CLASS;
+    }
+  }
+
+  public function typeImplements($name) {
+    return $this->reflect->implementsInterface($name);
+  }
+
+  /** @return php.Generator */
+  public function allInterfaces() {
+    foreach ($this->reflect->getInterfaces() as $interface) {
+      yield $interface->name => new self($interface);
+    }
+  }
+
+  /** @return php.Generator */
+  public function declaredInterfaces() {
+    $parent= $this->reflect->getParentClass();
+    $inherited= $parent ? array_flip($parent->getInterfaceNames()) : [];
+    foreach ($this->reflect->getInterfaces() as $interface) {
+      if (isset($inherited[$interface->getName()])) continue;
+      yield $interface->name => new self($interface);
     }
   }
 

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -83,6 +83,16 @@ class FromReflection extends \lang\Object implements Source {
   }
 
   /**
+   * Returns whether this type is a subtype of a given argument
+   *
+   * @param  string $class
+   * @return bool
+   */
+  public function isSubtypeOf($class) {
+    return $this->reflect->isSubclassOf($class);
+  }
+
+  /**
    * Returns whether this type implements a given interface
    *
    * @param  string $name
@@ -430,15 +440,11 @@ class FromReflection extends \lang\Object implements Source {
   }
 
   /**
-   * Returns whether this type is a subtype of a given argument
+   * Returns whether a given value is equal to this reflection source
    *
-   * @param  string $class
+   * @param  var $cmp
    * @return bool
    */
-  public function isSubtypeOf($class) {
-    return $this->reflect->isSubclassOf($class);
-  }
-
   public function equals($cmp) {
     return $cmp instanceof self && $this->name === $cmp->name;
   }

--- a/src/main/php/lang/mirrors/Interfaces.class.php
+++ b/src/main/php/lang/mirrors/Interfaces.class.php
@@ -20,7 +20,7 @@ class Interfaces extends \lang\Object implements \IteratorAggregate {
    */
   public function contains($arg) {
     return $this->mirror->reflect->implementsInterface($arg instanceof TypeMirror
-      ? $arg->reflect
+      ? strtr($arg->name(), '.', '\\')
       : strtr($arg, '.', '\\')
     );
   }

--- a/src/main/php/lang/mirrors/Interfaces.class.php
+++ b/src/main/php/lang/mirrors/Interfaces.class.php
@@ -19,11 +19,10 @@ class Interfaces extends \lang\Object implements \IteratorAggregate {
    * @return bool
    */
   public function contains($arg) {
-    return $this->mirror->reflect->typeImplements(strtr(
-      $arg instanceof TypeMirror ? $arg->name() : $arg,
-      '.',
-      '\\'
-    ));
+    return $this->mirror->reflect->typeImplements($arg instanceof TypeMirror
+      ? $arg->reflect->name
+      : strtr($arg, '.', '\\')
+    );
   }
 
   /**

--- a/src/main/php/lang/mirrors/Interfaces.class.php
+++ b/src/main/php/lang/mirrors/Interfaces.class.php
@@ -19,10 +19,11 @@ class Interfaces extends \lang\Object implements \IteratorAggregate {
    * @return bool
    */
   public function contains($arg) {
-    return $this->mirror->reflect->implementsInterface($arg instanceof TypeMirror
-      ? strtr($arg->name(), '.', '\\')
-      : strtr($arg, '.', '\\')
-    );
+    return $this->mirror->reflect->typeImplements(strtr(
+      $arg instanceof TypeMirror ? $arg->name() : $arg,
+      '.',
+      '\\'
+    ));
   }
 
   /**
@@ -31,7 +32,7 @@ class Interfaces extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function getIterator() {
-    foreach ($this->mirror->reflect->getInterfaces() as $interface) {
+    foreach ($this->mirror->reflect->allInterfaces() as $interface) {
       yield new TypeMirror($interface);
     }
   }
@@ -42,10 +43,7 @@ class Interfaces extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function declared() {
-    $parent= $this->mirror->reflect->getParentClass();
-    $inherited= $parent ? array_flip($parent->getInterfaceNames()) : [];
-    foreach ($this->mirror->reflect->getInterfaces() as $interface) {
-      if (isset($inherited[$interface->getName()])) continue;
+    foreach ($this->mirror->reflect->declaredInterfaces() as $interface) {
       yield new TypeMirror($interface);
     }
   }

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -7,7 +7,7 @@ use lang\mirrors\parse\TagsSource;
  * Base class for all type members: Fields, methods, constructors.
  */
 abstract class Member extends \lang\Object {
-  public static $STATIC= 0, $INSTANCE= 1;
+  public static $STATIC= false, $INSTANCE= true;
   public $reflect;
   protected $mirror;
   private $tags= null;
@@ -27,7 +27,7 @@ abstract class Member extends \lang\Object {
   public function name() { return $this->reflect['name']; }
 
   /** @return lang.mirrors.Modifiers */
-  public function modifiers() { return new Modifiers($this->reflect['access']); }
+  public function modifiers() { return $this->reflect['access']; }
 
   /** @return string */
   public function comment() {

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -72,25 +72,13 @@ abstract class Member extends \lang\Object {
    * @return lang.mirrors.TypeMirror
    */
   public function declaredIn() { 
-    if (is_array($this->reflect)) {
-      return $this->mirror->resolve($this->reflect['holder']);
-    }
-    $declaring= $this->reflect->getDeclaringClass();
-    if ($declaring->name === $this->mirror->reflect->name) {
-      return $this->mirror;
-    } else {
-      return new TypeMirror($declaring);
-    }
+    return $this->mirror->resolve($this->reflect['holder']);
   }
 
   /** @return lang.mirrors.Annotations */
   public function annotations() {
     $lookup= $this->mirror->reflect->codeUnit()->declaration()[static::$kind];
-if (is_array($this->reflect)) {
     $name= $this->reflect['name'];
-} else {
-    $name= $this->reflect->name;
-}
     return new Annotations(
       $this->mirror,
       isset($lookup[$name]['annotations'][null]) ? (array)$lookup[$name]['annotations'][null] : []
@@ -104,11 +92,9 @@ if (is_array($this->reflect)) {
    * @return bool
    */
   public function equals($cmp) {
-    $thisDecl= is_array($this->reflect) ? $this->reflect['holder'] : $this->reflect->getDeclaringClass()->name;
-    $cmpDecl= is_array($cmp->reflect) ? $cmp->reflect['holder'] : $cmp->reflect->getDeclaringClass()->name;
     return $cmp instanceof self && (
       $this->name === $cmp->name &&
-      $thisDecl === $cmpDecl
+      $this->reflect['holder'] === $cmp->reflect['holder']
     );
   }
 

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -7,7 +7,7 @@ use lang\mirrors\parse\TagsSource;
  * Base class for all type members: Fields, methods, constructors.
  */
 abstract class Member extends \lang\Object {
-  public static $STATIC= false, $INSTANCE= true;
+  public static $STATIC= 0x0001, $INSTANCE= 0x0002, $DECLARED= 0x0004;
   public $reflect;
   protected $mirror;
   private $tags= null;

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -13,10 +13,10 @@ abstract class Member extends \lang\Object {
   private $tags= null;
 
   /**
-   * Creates a new method
+   * Creates a new member
    *
    * @param  lang.mirrors.TypeMirror $mirror The type this member belongs to.
-   * @param  var $reflect A reflection object
+   * @param  [:var] $reflect
    */
   public function __construct($mirror, $reflect) {
     $this->mirror= $mirror;
@@ -24,29 +24,15 @@ abstract class Member extends \lang\Object {
   }
 
   /** @return string */
-  public function name() {
-if (is_array($this->reflect)) {
-  return $this->reflect['name'];
-}
-    return $this->reflect->name; }
+  public function name() { return $this->reflect['name']; }
 
   /** @return lang.mirrors.Modifiers */
-  public function modifiers() {
-if (is_array($this->reflect)) {
-  return new Modifiers($this->reflect['access']);
-}
-   return new Modifiers($this->reflect->getModifiers() & ~0x1fb7f008); }
+  public function modifiers() { return new Modifiers($this->reflect['access']); }
 
   /** @return string */
   public function comment() {
-if (is_array($this->reflect)) {
     $raw= $this->reflect['comment']();
-} else {
-    $raw= $this->reflect->getDocComment();
-}
-    if (false === $raw) {
-      return null;
-    } else {
+    if ($raw) {
       $text= trim(preg_replace('/\n\s+\* ?/', "\n", "\n".substr(
         $raw,
         4,                          // "/**\n"
@@ -54,6 +40,7 @@ if (is_array($this->reflect)) {
       )));
       return '' === $text ? null : $text;
     }
+    return null;
   }
 
   /**
@@ -63,11 +50,7 @@ if (is_array($this->reflect)) {
    */
   public function tags() {
     if (null === $this->tags) {
-if (is_array($this->reflect)) {
-    $raw= $this->reflect['comment']();
-} else {
-    $raw= $this->reflect->getDocComment();
-}
+      $raw= $this->reflect['comment']();
       if ($raw) {
         $parsed= (new TagsSyntax())->parse(new TagsSource(preg_replace('/\n\s+\* ?/', "\n", substr(
           $raw,
@@ -75,6 +58,8 @@ if (is_array($this->reflect)) {
           - 2                         // "*/"
         ))));
         $this->tags= array_merge(static::$tags, $parsed);
+      } else {
+        $this->tags= static::$tags;
       }
     }
     return $this->tags;

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -100,8 +100,12 @@ if (is_array($this->reflect)) {
 
   /** @return lang.mirrors.Annotations */
   public function annotations() {
-    $lookup= $this->mirror->unit()->declaration()[static::$kind];
+    $lookup= $this->mirror->reflect->codeUnit()->declaration()[static::$kind];
+if (is_array($this->reflect)) {
+    $name= $this->reflect['name'];
+} else {
     $name= $this->reflect->name;
+}
     return new Annotations(
       $this->mirror,
       isset($lookup[$name]['annotations'][null]) ? (array)$lookup[$name]['annotations'][null] : []

--- a/src/main/php/lang/mirrors/Method.class.php
+++ b/src/main/php/lang/mirrors/Method.class.php
@@ -18,22 +18,17 @@ class Method extends Routine {
    * Creates a new method
    *
    * @param  lang.mirrors.TypeMirror $mirror
-   * @param  [:var] $reflect
+   * @param  var $arg A map returned from Source::methodNamed(), a ReflectionMethod or a string
    * @throws lang.IllegalArgumentException If there is no such method
    */
   public function __construct($mirror, $arg) {
     if (is_array($arg)) {
-      $reflect= $arg;
+      parent::__construct($mirror, $arg);
     } else if ($arg instanceof \ReflectionMethod) {
-      $reflect= $mirror->reflect->methodNamed($arg->name);
+      parent::__construct($mirror, $mirror->reflect->methodNamed($arg->name));
     } else {
-      try {
-        $reflect= $mirror->reflect->methodNamed($arg);
-      } catch (\Exception $e) {
-        throw new IllegalArgumentException('No method named '.$arg.'() in '.$mirror->name());
-      }
+      parent::__construct($mirror, $mirror->reflect->methodNamed($arg));
     }
-    parent::__construct($mirror, $reflect);
   }
 
   /**

--- a/src/main/php/lang/mirrors/Method.class.php
+++ b/src/main/php/lang/mirrors/Method.class.php
@@ -18,17 +18,17 @@ class Method extends Routine {
    * Creates a new method
    *
    * @param  lang.mirrors.TypeMirror $mirror
-   * @param  var $arg Either a ReflectionMethod or a string
+   * @param  [:var] $reflect
    * @throws lang.IllegalArgumentException If there is no such method
    */
   public function __construct($mirror, $arg) {
     if (is_array($arg)) {
       $reflect= $arg;
     } else if ($arg instanceof \ReflectionMethod) {
-      $reflect= $arg;
+      $reflect= $mirror->reflect->methodNamed($arg->name);
     } else {
       try {
-        $reflect= $mirror->reflect->getMethod($arg);
+        $reflect= $mirror->reflect->methodNamed($arg);
       } catch (\Exception $e) {
         throw new IllegalArgumentException('No method named '.$arg.'() in '.$mirror->name());
       }
@@ -56,16 +56,7 @@ class Method extends Routine {
    * @throws lang.IllegalArgumentException
    */
   public function invoke(Generic $instance= null, $args= []) {
-if (is_array($this->reflect)) {
-  return $this->mirror->reflect->invokeMethod($this->reflect['value'], $instance, $args);
-}
-    try {
-      return $this->reflect->invokeArgs($instance, $args);
-    } catch (Throwable $e) {
-      throw new TargetInvocationException('Invoking '.$this->name().'() raised '.$e->getClassName(), $e);
-    } catch (\Exception $e) {
-      throw new IllegalArgumentException('Verifying '.$this->name().'(): '.$e->getMessage());
-    }
+    return $this->mirror->reflect->invokeMethod($this->reflect['value'], $instance, $args);
   }
 
   /** @return string */

--- a/src/main/php/lang/mirrors/Method.class.php
+++ b/src/main/php/lang/mirrors/Method.class.php
@@ -51,7 +51,7 @@ class Method extends Routine {
    * @throws lang.IllegalArgumentException
    */
   public function invoke(Generic $instance= null, $args= []) {
-    return $this->mirror->reflect->invokeMethod($this->reflect['value'], $instance, $args);
+    return $this->reflect['invoke']($instance, $args);
   }
 
   /** @return string */

--- a/src/main/php/lang/mirrors/Method.class.php
+++ b/src/main/php/lang/mirrors/Method.class.php
@@ -22,7 +22,9 @@ class Method extends Routine {
    * @throws lang.IllegalArgumentException If there is no such method
    */
   public function __construct($mirror, $arg) {
-    if ($arg instanceof \ReflectionMethod) {
+    if (is_array($arg)) {
+      $reflect= $arg;
+    } else if ($arg instanceof \ReflectionMethod) {
       $reflect= $arg;
     } else {
       try {
@@ -54,6 +56,9 @@ class Method extends Routine {
    * @throws lang.IllegalArgumentException
    */
   public function invoke(Generic $instance= null, $args= []) {
+if (is_array($this->reflect)) {
+  return $this->mirror->reflect->invokeMethod($this->reflect['value'], $instance, $args);
+}
     try {
       return $this->reflect->invokeArgs($instance, $args);
     } catch (Throwable $e) {

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -33,7 +33,7 @@ class Methods extends \lang\Object implements \IteratorAggregate {
    */
   public function named($name) {
     if ($this->provides($name)) {
-      return new Method($this->mirror, $this->mirror->reflect->getMethod($name));
+      return new Method($this->mirror, $this->mirror->reflect->methodNamed($name));
     }
     throw new ElementNotFoundException('No method '.$name.'() in '.$this->mirror->name());
   }
@@ -44,8 +44,8 @@ class Methods extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function getIterator() {
-    foreach ($this->mirror->reflect->getMethods() as $method) {
-      if (0 === strncmp($method->name, '__', 2)) continue;
+    foreach ($this->mirror->reflect->allMethods() as $name => $method) {
+      if (0 === strncmp($name, '__', 2)) continue;
       yield new Method($this->mirror, $method);
     }
   }
@@ -56,8 +56,8 @@ class Methods extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function declared() {
-    foreach ($this->mirror->reflect->getMethods() as $method) {
-      if (0 === strncmp('__', $method->name, 2) || $method->getDeclaringClass()->name !== $this->mirror->reflect->name) continue;
+    foreach ($this->mirror->reflect->declaredMethods() as $name => $method) {
+      if (0 === strncmp('__', $name, 2)) continue;
       yield new Method($this->mirror, $method);
     }
   }
@@ -69,8 +69,8 @@ class Methods extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public function of($kind) {
-    foreach ($this->mirror->reflect->getMethods() as $method) {
-      if (0 === strncmp('__', $method->name, 2) || $kind === ($method->getModifiers() & MODIFIER_STATIC)) continue;
+    foreach ($this->mirror->reflect->allMethods() as $name => $method) {
+      if (0 === strncmp('__', $name, 2) || $kind === ($method['access'] & MODIFIER_STATIC)) continue;
       yield new Method($this->mirror, $method);
     }
   }

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -70,7 +70,7 @@ class Methods extends \lang\Object implements \IteratorAggregate {
    */
   public function of($kind) {
     foreach ($this->mirror->reflect->allMethods() as $name => $method) {
-      if (0 === strncmp('__', $name, 2) || $kind === ($method['access'] & MODIFIER_STATIC)) continue;
+      if (0 === strncmp('__', $name, 2) || $kind === ($method['access']->isStatic())) continue;
       yield new Method($this->mirror, $method);
     }
   }

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -65,12 +65,17 @@ class Methods extends \lang\Object implements \IteratorAggregate {
   /**
    * Iterates over methods.
    *
-   * @param  int $kind Either Member::$STATIC or Member::$INSTANCE
+   * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
    * @return php.Generator
    */
   public function of($kind) {
-    foreach ($this->mirror->reflect->allMethods() as $name => $method) {
-      if (0 === strncmp('__', $name, 2) || $kind === ($method['access']->isStatic())) continue;
+    $instance= ($kind & Member::$STATIC) === 0;
+    $methods= ($kind & Member::$DECLARED)
+      ? $this->mirror->reflect->declaredMethods()
+      : $this->mirror->reflect->allMethods()
+    ;
+    foreach ($methods as $name => $method) {
+      if (0 === strncmp('__', $name, 2) || $instance === $method['access']->isStatic()) continue;
       yield new Method($this->mirror, $method);
     }
   }

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -1,7 +1,6 @@
 <?php namespace lang\mirrors;
 
 use lang\Type;
-use lang\XPClass;
 use lang\IllegalArgumentException;
 use lang\IllegalStateException;
 
@@ -21,55 +20,48 @@ class Parameter extends \lang\Object {
    * @throws lang.IllegalArgumentException If there is no such parameter
    */
   public function __construct($mirror, $arg) {
-    if ($arg instanceof \ReflectionParameter) {
+    if (is_array($arg)) {
       $this->reflect= $arg;
+    } else if ($arg instanceof \ReflectionParameter) {
+      $params= $mirror->reflect['params']();
+      $this->reflect= $params[$arg->getPosition()];
     } else {
-      try {
-        $this->reflect= new \ReflectionParameter([$mirror->reflect['holder'], $mirror->reflect['name']], $arg);
-      } catch (\Exception $e) {
+      $params= $mirror->reflect['params']();
+      if (!isset($params[$arg])) {
         throw new IllegalArgumentException('No parameter '.$arg.' in '.$mirror->name());
       }
+      $this->reflect= $params[$arg];
     }
     $this->mirror= $mirror;
   }
 
   /** @return string */
-  public function name() { return $this->reflect->name; }
+  public function name() { return $this->reflect['name']; }
 
   /** @return int */
-  public function position() { return $this->reflect->getPosition(); }
+  public function position() { return $this->reflect['pos']; }
 
   /** @return bool */
-  public function isOptional() { return $this->reflect->isOptional(); }
+  public function isVariadic() { return $this->reflect['var']; }
 
   /** @return bool */
-  public function isVariadic() { return $this->reflect->isVariadic(); }
+  public function isOptional() { return isset($this->reflect['default']); }
 
   /** @return bool */
-  public function isVerified() {
-    return (
-      $this->reflect->isArray() ||
-      $this->reflect->isCallable() ||
-      $this->reflect->getClass()
-    );
-  }
+  public function isVerified() { return isset($this->reflect['type']); }
 
   /** @return lang.Type */
   public function type() {
-    if ($this->reflect->isArray()) {
-      return Type::$ARRAY;
-    } else if ($this->reflect->isCallable()) {
-      return Type::$CALLABLE;
-    } else if (null === ($class= $this->reflect->getClass())) {
+    if (null === $this->reflect['type']) {
       $params= $this->mirror->tags()['param'];
-      $n= $this->reflect->getPosition();
+      $n= $this->reflect['pos'];
       if (isset($params[$n])) {
         return $params[$n]->resolve($this->mirror->declaredIn());
       } else {
         return Type::$VAR;
       }
     } else {
-      return new XPClass($class);
+      return $this->reflect['type']();
     }
   }
 
@@ -80,8 +72,8 @@ class Parameter extends \lang\Object {
    * @throws lang.IllegalStateException
    */
   public function defaultValue() {
-    if ($this->reflect->isOptional() && !$this->reflect->isVariadic()) {
-      return $this->reflect->getDefaultValue();
+    if (isset($this->reflect['default'])) {
+      return $this->reflect['default']();
     }
     throw new IllegalStateException('Parameter is not optional');
   }
@@ -91,7 +83,7 @@ class Parameter extends \lang\Object {
     $declared= $this->mirror->declaredIn();
     $lookup= $declared->unit()->declaration()['method'];
     $method= $this->mirror->reflect['name'];
-    $name= '$'.$this->reflect->name;
+    $name= '$'.$this->reflect['name'];
     return new Annotations(
       $declared,
       isset($lookup[$method]['annotations'][$name]) ? $lookup[$method]['annotations'][$name] : []
@@ -109,6 +101,6 @@ class Parameter extends \lang\Object {
 
   /** @return string */
   public function __toString() {
-    return $this->type().' $'.$this->name();
+    return $this->type().($this->reflect['var'] ? '...' : '').' $'.$this->name();
   }
 }

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -25,7 +25,7 @@ class Parameter extends \lang\Object {
       $this->reflect= $arg;
     } else {
       try {
-        $this->reflect= new \ReflectionParameter([$mirror->reflect->class, $mirror->reflect->name], $arg);
+        $this->reflect= new \ReflectionParameter([$mirror->reflect['holder'], $mirror->reflect['name']], $arg);
       } catch (\Exception $e) {
         throw new IllegalArgumentException('No parameter '.$arg.' in '.$mirror->name());
       }
@@ -90,7 +90,7 @@ class Parameter extends \lang\Object {
   public function annotations() {
     $declared= $this->mirror->declaredIn();
     $lookup= $declared->unit()->declaration()['method'];
-    $method= $this->mirror->reflect->name;
+    $method= $this->mirror->reflect['name'];
     $name= '$'.$this->reflect->name;
     return new Annotations(
       $declared,

--- a/src/main/php/lang/mirrors/Parameters.class.php
+++ b/src/main/php/lang/mirrors/Parameters.class.php
@@ -36,7 +36,7 @@ class Parameters extends \lang\Object implements \IteratorAggregate {
       $params= $this->reflect['params']();
       $this->lookup= [self::BY_ID => $params, self::BY_NAME => []];
       foreach ($params as $pos => $param) {
-        $this->lookup[self::BY_NAME][$param->name]= $pos;
+        $this->lookup[self::BY_NAME][$param['name']]= $pos;
       }
     }
     return $this->lookup;

--- a/src/main/php/lang/mirrors/Parameters.class.php
+++ b/src/main/php/lang/mirrors/Parameters.class.php
@@ -24,7 +24,7 @@ class Parameters extends \lang\Object implements \IteratorAggregate {
    *
    * @return bool
    */
-  public function present() { return $this->reflect->getNumberOfParameters() > 0; }
+  public function present() { return !empty($this->lookup()[self::BY_ID]); } 
 
   /**
    * Populates lookup maps BY_ID and BY_NAME lazily, then returns it.
@@ -33,7 +33,13 @@ class Parameters extends \lang\Object implements \IteratorAggregate {
    */
   private function lookup() {
     if (null === $this->lookup) {
+
+if (is_array($this->reflect)) {
+      $params= $this->reflect['params']();
+} else {
       $params= $this->reflect->getParameters();
+}
+
       $this->lookup= [self::BY_ID => $params, self::BY_NAME => []];
       foreach ($params as $pos => $param) {
         $this->lookup[self::BY_NAME][$param->name]= $pos;
@@ -57,9 +63,7 @@ class Parameters extends \lang\Object implements \IteratorAggregate {
    *
    * @return int
    */
-  public function length() {
-    return $this->reflect->getNumberOfParameters();
-  }
+  public function length() { return sizeof($this->lookup()[self::BY_ID]); }
 
   /**
    * Returns a given method if provided or raises an exception

--- a/src/main/php/lang/mirrors/Parameters.class.php
+++ b/src/main/php/lang/mirrors/Parameters.class.php
@@ -12,7 +12,7 @@ class Parameters extends \lang\Object implements \IteratorAggregate {
    * Creates a new parameters instance
    *
    * @param  lang.mirrors.Method $mirror
-   * @param  php.ReflectionMethod $reflect
+   * @param  [:var] $reflect
    */
   public function __construct($mirror, $reflect) {
     $this->mirror= $mirror;
@@ -33,13 +33,7 @@ class Parameters extends \lang\Object implements \IteratorAggregate {
    */
   private function lookup() {
     if (null === $this->lookup) {
-
-if (is_array($this->reflect)) {
       $params= $this->reflect['params']();
-} else {
-      $params= $this->reflect->getParameters();
-}
-
       $this->lookup= [self::BY_ID => $params, self::BY_NAME => []];
       foreach ($params as $pos => $param) {
         $this->lookup[self::BY_NAME][$param->name]= $pos;

--- a/src/main/php/lang/mirrors/Routine.class.php
+++ b/src/main/php/lang/mirrors/Routine.class.php
@@ -19,7 +19,6 @@ abstract class Routine extends Member {
    */
   public function __construct($mirror, $reflect) {
     parent::__construct($mirror, $reflect);
-    $reflect->setAccessible(true);
     $this->parameters= new Parameters($this, $reflect);
   }
 

--- a/src/main/php/lang/mirrors/Source.class.php
+++ b/src/main/php/lang/mirrors/Source.class.php
@@ -1,0 +1,4 @@
+<?php namespace lang\mirrors;
+
+interface Source {
+}

--- a/src/main/php/lang/mirrors/Source.class.php
+++ b/src/main/php/lang/mirrors/Source.class.php
@@ -122,6 +122,7 @@ interface Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function fieldNamed($name);
 
@@ -130,6 +131,7 @@ interface Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function methodNamed($name);
 
@@ -138,6 +140,7 @@ interface Source {
    *
    * @param  string $name
    * @return var
+   * @throws lang.ElementNotFoundException
    */
   public function constantNamed($name);
 

--- a/src/main/php/lang/mirrors/Source.class.php
+++ b/src/main/php/lang/mirrors/Source.class.php
@@ -54,6 +54,18 @@ interface Source {
   public function typeUses($name);
 
   /** @return php.Generator */
+  public function declaredInterfaces();
+
+  /** @return php.Generator */
+  public function allTraits();
+
+  /** @return php.Generator */
+  public function declaredTraits();
+
+  /** @return var */
+  public function constructor();
+
+  /** @return php.Generator */
   public function allFields();
 
   /** @return php.Generator */
@@ -71,23 +83,13 @@ interface Source {
   /** @return php.Generator */
   public function allInterfaces();
 
-  /** @return php.Generator */
-  public function declaredInterfaces();
-
-  /** @return php.Generator */
-  public function allTraits();
-
-  /** @return php.Generator */
-  public function declaredTraits();
-
-  /** @return var */
-  public function constructor();
-
   /**
    * Creates a new instance
    *
    * @param  var[] $args
    * @return lang.Generic
+   * @throws lang.IllegalArgumentException
+   * @throws lang.mirrors.TargetInvocationException
    */
   public function newInstance($args);
 

--- a/src/main/php/lang/mirrors/Source.class.php
+++ b/src/main/php/lang/mirrors/Source.class.php
@@ -1,4 +1,149 @@
 <?php namespace lang\mirrors;
 
 interface Source {
+
+  /** @return lang.mirrors.parse.CodeUnit */
+  public function codeUnit();
+
+  /** @return string */
+  public function typeName();
+
+  /** @return string */
+  public function packageName();
+
+  /** @return string */
+  public function typeDeclaration();
+
+  /** @return self */
+  public function typeParent();
+
+  /** @return string */
+  public function typeComment();
+
+  /** @return var */
+  public function typeAnnotations();
+
+  /** @return lang.mirrors.Modifiers */
+  public function typeModifiers();
+
+  /** @return lang.mirrors.Kind */
+  public function typeKind();
+
+  /**
+   * Returns whether this type is a subtype of a given argument
+   *
+   * @param  string $class
+   * @return bool
+   */
+  public function isSubtypeOf($class);
+
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @param  bool
+   */
+  public function typeImplements($name);
+
+  /** @return php.Generator */
+  public function allInterfaces();
+
+  /** @return php.Generator */
+  public function declaredInterfaces();
+
+  /** @return php.Generator */
+  public function allTraits();
+
+  /** @return php.Generator */
+  public function declaredTraits();
+
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @param  bool
+   */
+  public function typeUses($name);
+
+  /** @return [:var] */
+  public function constructor();
+
+  /**
+   * Creates a new instance
+   *
+   * @param  var[] $args
+   * @return lang.Generic
+   */
+  public function newInstance($args);
+
+  /**
+   * Checks whether a given field exists
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function hasField($name);
+
+  /**
+   * Gets a field by its name
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function fieldNamed($name);
+
+  /** @return php.Generator */
+  public function allFields();
+
+  /** @return php.Generator */
+  public function declaredFields();
+
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function hasMethod($name);
+
+  /**
+   * Gets a method by its name
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function methodNamed($name);
+
+  /** @return php.Generator */
+  public function allMethods();
+
+  /** @return php.Generator */
+  public function declaredMethods();
+
+  /**
+   * Checks whether a given constant exists
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function hasConstant($name);
+
+  /**
+   * Gets a constant by its name
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function constantNamed($name);
+
+  /** @return php.Generator */
+  public function allConstants();
+
+  /**
+   * Resolves a type name in the context of this reflection source
+   *
+   * @param  string $name
+   * @return self
+   */
+  public function resolve($name);
 }

--- a/src/main/php/lang/mirrors/Source.class.php
+++ b/src/main/php/lang/mirrors/Source.class.php
@@ -20,7 +20,7 @@ interface Source {
   /** @return string */
   public function typeComment();
 
-  /** @return var */
+  /** @return [:var] */
   public function typeAnnotations();
 
   /** @return lang.mirrors.Modifiers */
@@ -41,9 +41,32 @@ interface Source {
    * Returns whether this type implements a given interface
    *
    * @param  string $name
-   * @param  bool
+   * @return bool
    */
   public function typeImplements($name);
+
+  /**
+   * Returns whether this type implements a given interface
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function typeUses($name);
+
+  /** @return php.Generator */
+  public function allFields();
+
+  /** @return php.Generator */
+  public function declaredFields();
+
+  /** @return php.Generator */
+  public function allMethods();
+
+  /** @return php.Generator */
+  public function declaredMethods();
+
+  /** @return php.Generator */
+  public function allConstants();
 
   /** @return php.Generator */
   public function allInterfaces();
@@ -57,15 +80,7 @@ interface Source {
   /** @return php.Generator */
   public function declaredTraits();
 
-  /**
-   * Returns whether this type implements a given interface
-   *
-   * @param  string $name
-   * @param  bool
-   */
-  public function typeUses($name);
-
-  /** @return [:var] */
+  /** @return var */
   public function constructor();
 
   /**
@@ -85,40 +100,12 @@ interface Source {
   public function hasField($name);
 
   /**
-   * Gets a field by its name
-   *
-   * @param  string $name
-   * @return var
-   */
-  public function fieldNamed($name);
-
-  /** @return php.Generator */
-  public function allFields();
-
-  /** @return php.Generator */
-  public function declaredFields();
-
-  /**
    * Checks whether a given method exists
    *
    * @param  string $name
    * @return bool
    */
   public function hasMethod($name);
-
-  /**
-   * Gets a method by its name
-   *
-   * @param  string $name
-   * @return var
-   */
-  public function methodNamed($name);
-
-  /** @return php.Generator */
-  public function allMethods();
-
-  /** @return php.Generator */
-  public function declaredMethods();
 
   /**
    * Checks whether a given constant exists
@@ -129,15 +116,28 @@ interface Source {
   public function hasConstant($name);
 
   /**
+   * Gets a field by its name
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function fieldNamed($name);
+
+  /**
+   * Gets a method by its name
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function methodNamed($name);
+
+  /**
    * Gets a constant by its name
    *
    * @param  string $name
    * @return var
    */
   public function constantNamed($name);
-
-  /** @return php.Generator */
-  public function allConstants();
 
   /**
    * Resolves a type name in the context of this reflection source

--- a/src/main/php/lang/mirrors/Sources.class.php
+++ b/src/main/php/lang/mirrors/Sources.class.php
@@ -1,0 +1,26 @@
+<?php namespace lang\mirrors;
+
+abstract class Sources extends \lang\Enum {
+  public static $CODE, $REFLECTION;
+
+  static function __static() {
+    self::$REFLECTION= newinstance(self::class, [0, 'REFLECTION'], '{
+      static function __static() { }
+
+      public function reflect($name) {
+        try {
+          return new FromReflection(new \ReflectionClass(strtr($name, ".", "\\\\")));
+        } catch (\Exception $e) {
+          throw new \lang\ClassNotFoundException($name.": ".$e->getMessage());
+        }
+      }
+    }');
+    self::$CODE= newinstance(self::class, [1, 'CODE'], '{
+      static function __static() { }
+
+      public function reflect($name) { return new FromCode($name); }
+    }');
+  }
+
+  public abstract function reflect($name);
+}

--- a/src/main/php/lang/mirrors/Sources.class.php
+++ b/src/main/php/lang/mirrors/Sources.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\mirrors;
 
 abstract class Sources extends \lang\Enum {
-  public static $CODE, $REFLECTION;
+  public static $REFLECTION, $CODE;
 
   static function __static() {
     self::$REFLECTION= newinstance(self::class, [0, 'REFLECTION'], '{

--- a/src/main/php/lang/mirrors/Sources.class.php
+++ b/src/main/php/lang/mirrors/Sources.class.php
@@ -9,7 +9,7 @@ abstract class Sources extends \lang\Enum {
 
       public function reflect($class) {
         if ($class instanceof \ReflectionClass) {
-          return new FromReflection($class);
+          return self::$REFLECTION->reflect($class, $this);
         } else {
           $literal= strtr($class, ".", "\\\\");
           if (class_exists($literal) || interface_exists($literal) || trait_exists($literal)) {

--- a/src/main/php/lang/mirrors/Sources.class.php
+++ b/src/main/php/lang/mirrors/Sources.class.php
@@ -16,7 +16,7 @@ abstract class Sources extends \lang\Enum {
           if (class_exists($literal) || interface_exists($literal) || trait_exists($literal)) {
             return self::$REFLECTION->reflect($class, $source ?: $this);
           } else if (\lang\ClassLoader::getDefault()->providesClass($dotted)) {
-            return self::$CODE->reflect($dotted, $source ?: $this);
+            return new FromCode($dotted, $source ?: $this);
           } else {
             return new FromIncomplete($literal);
           }

--- a/src/main/php/lang/mirrors/Sources.class.php
+++ b/src/main/php/lang/mirrors/Sources.class.php
@@ -34,5 +34,12 @@ abstract class Sources extends \lang\Enum {
     }');
   }
 
+  /**
+   * Creates a reflection source for a given class
+   *
+   * @param  string $class
+   * @return lang.mirrors.Source
+   * @throws lang.ClassNotFoundException
+   */
   public abstract function reflect($class);
 }

--- a/src/main/php/lang/mirrors/Sources.class.php
+++ b/src/main/php/lang/mirrors/Sources.class.php
@@ -1,5 +1,15 @@
 <?php namespace lang\mirrors;
 
+/**
+ * Sources from which reflection can be created:
+ *
+ * - DEFAULT: Uses reflection if class exists, parsing code otherwise
+ * - REFLECTION: Uses ext/reflection
+ * - CODE: Parses code.
+ *
+ * Has special case handling to cope with situation that class is not
+ * fully defined (e.g. when performing compile-time metaprogramming).
+ */
 abstract class Sources extends \lang\Enum {
   public static $DEFAULT, $REFLECTION, $CODE;
 
@@ -10,16 +20,16 @@ abstract class Sources extends \lang\Enum {
       public function reflect($class, $source= null) {
         if ($class instanceof \ReflectionClass) {
           return new FromReflection($class, $source ?: $this);
+        }
+
+        $literal= strtr($class, ".", "\\\\");
+        $dotted= strtr($class, "\\\\", ".");
+        if (class_exists($literal) || interface_exists($literal) || trait_exists($literal)) {
+          return self::$REFLECTION->reflect($class, $source ?: $this);
+        } else if (\lang\ClassLoader::getDefault()->providesClass($dotted)) {
+          return new FromCode($dotted, $source ?: $this);
         } else {
-          $literal= strtr($class, ".", "\\\\");
-          $dotted= strtr($class, "\\\\", ".");
-          if (class_exists($literal) || interface_exists($literal) || trait_exists($literal)) {
-            return self::$REFLECTION->reflect($class, $source ?: $this);
-          } else if (\lang\ClassLoader::getDefault()->providesClass($dotted)) {
-            return new FromCode($dotted, $source ?: $this);
-          } else {
-            return new FromIncomplete($literal);
-          }
+          return new FromIncomplete($literal);
         }
       }
     }');
@@ -27,11 +37,12 @@ abstract class Sources extends \lang\Enum {
       static function __static() { }
 
       public function reflect($class, $source= null) {
+        if ($class instanceof \ReflectionClass) {
+          return new FromReflection($class, $source);
+        }
+
         try {
-          return new FromReflection(
-            $class instanceof \ReflectionClass ? $class : new \ReflectionClass(strtr($class, ".", "\\\\")),
-            $source
-          );
+          return new FromReflection(new \ReflectionClass(strtr($class, ".", "\\\\")), $source);
         } catch (\Exception $e) {
           throw new \lang\ClassNotFoundException($class.": ".$e->getMessage());
         }

--- a/src/main/php/lang/mirrors/Sources.class.php
+++ b/src/main/php/lang/mirrors/Sources.class.php
@@ -12,12 +12,13 @@ abstract class Sources extends \lang\Enum {
           return new FromReflection($class, $source ?: $this);
         } else {
           $literal= strtr($class, ".", "\\\\");
+          $dotted= strtr($class, "\\\\", ".");
           if (class_exists($literal) || interface_exists($literal) || trait_exists($literal)) {
             return self::$REFLECTION->reflect($class, $source ?: $this);
-          } else if (isset(\xp::$cl[strtr($class, "\\\\", ".")])) {
-            return new FromIncomplete($literal);
+          } else if (\lang\ClassLoader::getDefault()->providesClass($dotted)) {
+            return self::$CODE->reflect($dotted, $source ?: $this);
           } else {
-            return self::$CODE->reflect($class, $source ?: $this);
+            return new FromIncomplete($literal);
           }
         }
       }
@@ -40,7 +41,7 @@ abstract class Sources extends \lang\Enum {
       static function __static() { }
 
       public function reflect($class, $source= null) {
-        return new FromCode($class, $source);
+        return new FromCode(strtr($class, "\\\\", "."), $source);
       }
     }');
   }

--- a/src/main/php/lang/mirrors/Traits.class.php
+++ b/src/main/php/lang/mirrors/Traits.class.php
@@ -19,21 +19,31 @@ class Traits extends \lang\Object implements \IteratorAggregate {
    * @return bool
    */
   public function contains($arg) {
-    if ($arg instanceof TypeMirror) {
-      $name= $arg->reflect->name;
-    } else {
-      $name= strtr($arg, '.', '\\');
-    }
-    return in_array($name, $this->mirror->reflect->getTraitNames());
+    return $this->mirror->reflect->typeUses(strtr(
+      $arg instanceof TypeMirror ? $arg->name() : $arg,
+      '.',
+      '\\'
+    ));
   }
 
   /**
-   * Iterates over all fields
+   * Iterates over all traits
    *
    * @return php.Generator
    */
   public function getIterator() {
-    foreach ($this->mirror->reflect->getTraits() as $trait) {
+    foreach ($this->mirror->reflect->allTraits() as $trait) {
+      yield new TypeMirror($trait);
+    }
+  }
+
+  /**
+   * Returns only traits this type uses directly
+   *
+   * @return php.Generator
+   */
+  public function declared() {
+    foreach ($this->mirror->reflect->declaredTraits() as $trait) {
       yield new TypeMirror($trait);
     }
   }

--- a/src/main/php/lang/mirrors/Traits.class.php
+++ b/src/main/php/lang/mirrors/Traits.class.php
@@ -19,11 +19,10 @@ class Traits extends \lang\Object implements \IteratorAggregate {
    * @return bool
    */
   public function contains($arg) {
-    return $this->mirror->reflect->typeUses(strtr(
-      $arg instanceof TypeMirror ? $arg->name() : $arg,
-      '.',
-      '\\'
-    ));
+    return $this->mirror->reflect->typeUses($arg instanceof TypeMirror
+      ? $arg->reflect->name
+      : strtr($arg, '.', '\\')
+    );
   }
 
   /**

--- a/src/main/php/lang/mirrors/Traits.class.php
+++ b/src/main/php/lang/mirrors/Traits.class.php
@@ -32,6 +32,7 @@ class Traits extends \lang\Object implements \IteratorAggregate {
    */
   public function getIterator() {
     foreach ($this->mirror->reflect->allTraits() as $trait) {
+      if (0 === strncmp($trait->name, '__', 2)) continue;
       yield new TypeMirror($trait);
     }
   }
@@ -43,6 +44,7 @@ class Traits extends \lang\Object implements \IteratorAggregate {
    */
   public function declared() {
     foreach ($this->mirror->reflect->declaredTraits() as $trait) {
+      if (0 === strncmp($trait->name, '__', 2)) continue;
       yield new TypeMirror($trait);
     }
   }

--- a/src/main/php/lang/mirrors/Traits.class.php
+++ b/src/main/php/lang/mirrors/Traits.class.php
@@ -20,7 +20,7 @@ class Traits extends \lang\Object implements \IteratorAggregate {
    */
   public function contains($arg) {
     if ($arg instanceof TypeMirror) {
-      $name= $arg->reflect->getName();
+      $name= $arg->reflect->name;
     } else {
       $name= strtr($arg, '.', '\\');
     }

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -133,7 +133,7 @@ class TypeMirror extends \lang\Object {
 
   /** @return lang.mirrors.Annotations */
   public function annotations() {
-    $lookup= $this->unit()->declaration()['annotations'];
+    $lookup= $this->reflect->typeAnnotations();
     return new Annotations($this, isset($lookup[null]) ? $lookup[null] : []);
   }
 

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -5,7 +5,6 @@ use lang\mirrors\parse\ClassSource;
 use lang\ClassNotFoundException;
 use lang\IllegalArgumentException;
 use lang\XPClass;
-use lang\Enum;
 
 /**
  * Reference type mirrors
@@ -17,7 +16,6 @@ use lang\Enum;
  */
 class TypeMirror extends \lang\Object {
   private $methods, $fields, $constants;
-  private $kind= null, $unit= null;
   public $reflect;
 
   /**
@@ -77,28 +75,10 @@ class TypeMirror extends \lang\Object {
   public function interfaces() { return new Interfaces($this); }
 
   /** @return lang.mirrors.parse.CodeUnit */
-  public function unit() {
-    if (null === $this->unit) {
-      $this->unit= (new ClassSyntax())->parse(new ClassSource($this->name()));
-    }
-    return $this->unit;
-  }
+  public function unit() { return $this->reflect->codeUnit(); }
 
   /** @return lang.mirrors.Kind */
-  public function kind() {
-    if (null === $this->kind) {
-      if ($this->reflect->isTrait()) {
-        $this->kind= Kind::$TRAIT;
-      } else if ($this->reflect->isInterface()) {
-        $this->kind= Kind::$INTERFACE;
-      } else if ($this->reflect->isSubclassOf(Enum::class)) {
-        $this->kind= Kind::$ENUM;
-      } else {
-        $this->kind= Kind::$CLASS;
-      }
-    }
-    return $this->kind;
-  }
+  public function kind() { return $this->reflect->typeKind(); }
 
   /** @return lang.mirrors.Constructor */
   public function constructor() { return new Constructor($this); }

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -122,13 +122,13 @@ class TypeMirror extends \lang\Object {
   }
 
   /**
-   * Returns whether a given value is equal to this code unit
+   * Returns whether a given value is equal to this type mirror
    *
    * @param  var $cmp
    * @return bool
    */
   public function equals($cmp) {
-    return $cmp instanceof self && $this->reflect->name === $cmp->reflect->name;
+    return $cmp instanceof self && $this->reflect->equals($cmp->reflect);
   }
 
   /**

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -101,9 +101,7 @@ class TypeMirror extends \lang\Object {
   }
 
   /** @return lang.mirrors.Constructor */
-  public function constructor() {
-    return new Constructor($this);
-  }
+  public function constructor() { return new Constructor($this); }
 
   /** @return lang.mirrors.Methods */
   public function methods() { return $this->methods; }

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -113,21 +113,7 @@ class TypeMirror extends \lang\Object {
   public function constants() { return $this->constants; }
 
   /** @return lang.mirrors.Modifiers */
-  public function modifiers() {
-
-    // HHVM and PHP differ in this. We'll handle traits as *always* abstract (needs
-    // to be implemented) and *never* final (couldn't be implemented otherwise).
-    if ($this->reflect->isTrait()) {
-      return new Modifiers(Modifiers::IS_PUBLIC | Modifiers::IS_ABSTRACT);
-    } else {
-      $r= Modifiers::IS_PUBLIC;
-      $m= $this->reflect->getModifiers();
-      $m & \ReflectionClass::IS_EXPLICIT_ABSTRACT && $r |= Modifiers::IS_ABSTRACT;
-      $m & \ReflectionClass::IS_IMPLICIT_ABSTRACT && $r |= Modifiers::IS_ABSTRACT;
-      $m & \ReflectionClass::IS_FINAL && $r |= Modifiers::IS_FINAL;
-      return new Modifiers($r);
-    }
-  }
+  public function modifiers() { return $this->reflect->typeModifiers(); }
 
   /** @return lang.mirrors.Annotations */
   public function annotations() {
@@ -148,7 +134,7 @@ class TypeMirror extends \lang\Object {
       return $this->parent();
     } else if (strstr($name, '\\') || strstr($name, '.')) {
       return new self($name);
-    } else if ($name === $this->reflect->getShortName()) {
+    } else if ($name === $this->reflect->typeDeclaration()) {
       return $this;
     } else {
       $unit= $this->unit();

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -15,7 +15,7 @@ use lang\XPClass;
  * @test   xp://lang.mirrors.unittest.TypeMirrorTest
  */
 class TypeMirror extends \lang\Object {
-  private $methods, $fields, $constants;
+  private $methods, $fields;
   public $reflect;
 
   /**
@@ -40,7 +40,6 @@ class TypeMirror extends \lang\Object {
 
     $this->methods= new Methods($this);
     $this->fields= new Fields($this);
-    $this->constants= new Constants($this);
   }
 
   /** @return string */
@@ -90,7 +89,7 @@ class TypeMirror extends \lang\Object {
   public function fields() { return $this->fields; }
 
   /** @return lang.mirrors.Constants */
-  public function constants() { return $this->constants; }
+  public function constants() { return new Constants($this); }
 
   /** @return lang.mirrors.Modifiers */
   public function modifiers() { return $this->reflect->typeModifiers(); }

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -32,6 +32,8 @@ class TypeMirror extends \lang\Object {
       $this->reflect= new FromReflection($arg);
     } else if ($arg instanceof XPClass) {
       $this->reflect= new FromReflection($arg->_reflect);
+    } else if ($arg instanceof Source) {
+      $this->reflect= $arg;
     } else if (null === $source) {
       $this->reflect= Sources::$REFLECTION->reflect($arg);
     } else {
@@ -47,7 +49,7 @@ class TypeMirror extends \lang\Object {
   public function name() { return $this->reflect->typeName(); }
 
   /** @return string */
-  public function declaration() { return $this->reflect->getShortName(); }
+  public function declaration() { return $this->reflect->typeDeclaration(); }
 
   /** @return string */
   public function comment() {
@@ -64,7 +66,7 @@ class TypeMirror extends \lang\Object {
 
   /** @return self */
   public function parent() {
-    $parent= $this->reflect->getParentClass();
+    $parent= $this->reflect->typeParent();
     return $parent ? new self($parent) : null;
   }
 

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -119,7 +119,7 @@ class TypeMirror extends \lang\Object {
    */
   public function isSubtypeOf($arg) {
     $type= $arg instanceof self ? $arg->reflect->name : strtr($arg, '.', '\\');
-    return $this->reflect->isSubclassOf($type);
+    return $this->reflect->isSubtypeOf($type);
   }
 
   /**

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -33,7 +33,7 @@ class TypeMirror extends \lang\Object {
     } else if ($arg instanceof Source) {
       $this->reflect= $arg;
     } else if (null === $source) {
-      $this->reflect= Sources::$REFLECTION->reflect($arg);
+      $this->reflect= Sources::$DEFAULT->reflect($arg);
     } else {
       $this->reflect= $source->reflect($arg);
     }

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -108,21 +108,7 @@ class TypeMirror extends \lang\Object {
    * @return self
    */
   public function resolve($name) {
-    if ('self' === $name) {
-      return $this;
-    } else if ('parent' === $name) {
-      return $this->parent();
-    } else if (strstr($name, '\\') || strstr($name, '.')) {
-      return new self($name);
-    } else if ($name === $this->reflect->typeDeclaration()) {
-      return $this;
-    } else {
-      $unit= $this->reflect->codeUnit();
-      foreach ($unit->imports() as $imported) {
-        if (0 === substr_compare($imported, $name, strrpos($imported, '.') + 1)) return new self($imported);
-      }
-      return new self($unit->package().'.'.$name);
-    }
+    return new self($this->reflect->resolve($name));
   }
 
   /**

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -62,7 +62,7 @@ class TypeMirror extends \lang\Object {
   }
 
   /** @return lang.mirrors.Package */
-  public function package() { return new Package($this->reflect->getNamespaceName()); }
+  public function package() { return new Package($this->reflect->packageName()); }
 
   /** @return self */
   public function parent() {

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -51,7 +51,7 @@ class TypeMirror extends \lang\Object {
 
   /** @return string */
   public function comment() {
-    $comment= $this->reflect->getDocComment();
+    $comment= $this->reflect->typeComment();
     return false === $comment ? null : trim(preg_replace('/\n\s+\* ?/', "\n", "\n".substr(
       $comment,
       4,                              // "/**\n"
@@ -117,7 +117,7 @@ class TypeMirror extends \lang\Object {
     } else if ($name === $this->reflect->typeDeclaration()) {
       return $this;
     } else {
-      $unit= $this->unit();
+      $unit= $this->reflect->codeUnit();
       foreach ($unit->imports() as $imported) {
         if (0 === substr_compare($imported, $name, strrpos($imported, '.') + 1)) return new self($imported);
       }

--- a/src/main/php/lang/mirrors/parse/ClassSource.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSource.class.php
@@ -1,18 +1,26 @@
 <?php namespace lang\mirrors\parse;
 
 use lang\IllegalArgumentException;
+use lang\ClassLoader;
+use lang\IClassLoader;
+use lang\ClassNotFoundException;
 
 class ClassSource extends \text\parse\Tokens {
   protected $tokens;
   private $comment;
 
+  /**
+   * Creates a new class source
+   *
+   * @param  string $class Dotted fully qualified name
+   * @throws lang.ClassNotFoundException If class can not be located
+   */
   public function __construct($class) {
-    if (!isset(\xp::$cl[$class])) {
-      throw new IllegalArgumentException('No source for '.$class);
+    $cl= ClassLoader::getDefault()->findClass($class);
+    if (!$cl instanceof IClassLoader) {
+      throw new ClassNotFoundException('No source for '.$class);
     }
 
-    sscanf(\xp::$cl[$class], '%[^:]://%[^$]', $loader, $argument);
-    $cl= call_user_func([literal($loader), 'instanceFor'], $argument);
     $this->tokens= token_get_all($cl->loadClassBytes($class));
   }
 

--- a/src/main/php/lang/mirrors/parse/ClassSource.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSource.class.php
@@ -18,7 +18,7 @@ class ClassSource extends \text\parse\Tokens {
   public function __construct($class) {
     $cl= ClassLoader::getDefault()->findClass($class);
     if (!$cl instanceof IClassLoader) {
-      throw new ClassNotFoundException('No source for '.$class);
+      throw new ClassNotFoundException($class);
     }
 
     $this->tokens= token_get_all($cl->loadClassBytes($class));

--- a/src/main/php/lang/mirrors/parse/ClassSource.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSource.class.php
@@ -4,6 +4,7 @@ use lang\IllegalArgumentException;
 
 class ClassSource extends \text\parse\Tokens {
   protected $tokens;
+  private $comment;
 
   public function __construct($class) {
     if (!isset(\xp::$cl[$class])) {
@@ -14,6 +15,9 @@ class ClassSource extends \text\parse\Tokens {
     $cl= call_user_func([literal($loader), 'instanceFor'], $argument);
     $this->tokens= token_get_all($cl->loadClassBytes($class));
   }
+
+  /** @return string */
+  public function lastComment() { return $this->comment; }
 
   protected function next() {
     static $annotations= [T_COMMENT, T_WHITESPACE];
@@ -32,7 +36,7 @@ class ClassSource extends \text\parse\Tokens {
           $this->tokens= array_merge(array_slice(token_get_all($annotation), 1), [$token], $this->tokens);
         }
       } else if (T_DOC_COMMENT === $token[0]) {
-        // Skip
+        $this->comment= $token[1];
       } else {
         return $token;
       }

--- a/src/main/php/lang/mirrors/parse/ClassSource.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSource.class.php
@@ -19,6 +19,7 @@ class ClassSource extends \text\parse\Tokens {
   /** @return string */
   public function lastComment() { return $this->comment; }
 
+  /** @return var */
   protected function next() {
     static $annotations= [T_COMMENT, T_WHITESPACE];
 

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -13,6 +13,8 @@ use text\parse\rules\Collect;
 use text\parse\rules\OneOf;
 
 class ClassSyntax extends \text\parse\Syntax {
+  const CACHE_LIMIT = 20;
+  private static $cache= [];
 
   /** @return text.parse.Rules */
   protected function rules() {
@@ -198,5 +200,22 @@ class ClassSyntax extends \text\parse\Syntax {
         T_VARIABLE => function($values) { return $values[0]; },
       ])
     ]);
+  }
+
+  /**
+   * Parses a class
+   *
+   * @param  string $class Fully qualified class name
+   * @return lang.mirrors.parse.CodeUnit
+   */
+  public function codeUnitOf($class) {
+   $dotted= strtr($class, '\\', '.');
+   if (!isset(self::$cache[$dotted])) {
+      self::$cache[$dotted]= $this->parse(new ClassSource($dotted));
+      while (sizeof(self::$cache) > self::CACHE_LIMIT) {
+        unset(self::$cache[key(self::$cache)]);
+      }
+    }
+    return self::$cache[$dotted];
   }
 }

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -214,13 +214,12 @@ class ClassSyntax extends \text\parse\Syntax {
    * @return lang.mirrors.parse.CodeUnit
    */
   public function codeUnitOf($class) {
-    $dotted= strtr($class, '\\', '.');
-    if (!isset(self::$cache[$dotted])) {
-      self::$cache[$dotted]= $this->parse(new ClassSource($dotted));
+    if (!isset(self::$cache[$class])) {
+      self::$cache[$class]= $this->parse(new ClassSource($class));
       while (sizeof(self::$cache) > self::CACHE_LIMIT) {
         unset(self::$cache[key(self::$cache)]);
       }
     }
-    return self::$cache[$dotted];
+    return self::$cache[$class];
   }
 }

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -55,9 +55,9 @@ class ClassSyntax extends \text\parse\Syntax {
       ]),
       'decl' => new Sequence(
         [
+          new Returns(function($values, $source) { return $source->lastComment(); }),
           new Optional(new Apply('annotations')),
           new Apply('modifiers'),
-          new Returns(function($values, $source) { return $source->lastComment(); }),
           new Match([
             T_CLASS     => new Sequence([new Token(T_STRING), new Optional(new Apply('parent')), new Tokens(T_STRING, T_NS_SEPARATOR, T_IMPLEMENTS), new Apply('type')], function($values) {
               return array_merge(['kind' => $values[0], 'parent' => $values[2], 'name' => $values[1]], $values[4]);
@@ -70,7 +70,7 @@ class ClassSyntax extends \text\parse\Syntax {
             }),
           ])
         ],
-        function($values) { return array_merge($values[3], ['comment' => $values[2], 'modifiers' => $values[1], 'annotations' => $values[0]]); }
+        function($values) { return array_merge($values[3], ['comment' => $values[0], 'modifiers' => $values[2], 'annotations' => $values[1]]); }
       ),
       'parent' => new Sequence(
         [new Token(T_EXTENDS), $typeName],

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -136,12 +136,13 @@ class ClassSyntax extends \text\parse\Syntax {
       'modifiers' => new Tokens(T_PUBLIC, T_PRIVATE, T_PROTECTED, T_STATIC, T_FINAL, T_ABSTRACT),
       'param' => new Sequence(
         [
-          new Tokens(T_ARRAY, T_CALLABLE, T_STRING, T_NS_SEPARATOR, T_ELLIPSIS),
+          new Tokens(T_ARRAY, T_CALLABLE, T_STRING, T_NS_SEPARATOR),
+          new Optional(new Token(T_ELLIPSIS)),
           new Optional(new Token('&')),
           new Token(T_VARIABLE),
           new Optional(new Sequence([new Token('='), new Apply('expr')], function($values) { return $values[1]; }))
         ],
-        function($values) { return ['name' => $values[2], 'type' => $values[0] ? implode('', $values[0]) : null, 'ref' => isset($values[1]), 'default' => $values[3]]; }
+        function($values) { return ['name' => substr($values[3], 1), 'type' => $values[0] ? implode('', $values[0]) : null, 'ref' => isset($values[2]), 'var' => isset($values[1]), 'default' => $values[4]]; }
       ),
       'method' => new Match([';' => null, '{' => new Block(true)]),
       'expr' => new OneOf([

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -61,8 +61,12 @@ class ClassSyntax extends \text\parse\Syntax {
             T_CLASS     => new Sequence([new Token(T_STRING), new Optional(new Apply('parent')), new Tokens(T_STRING, T_NS_SEPARATOR, T_IMPLEMENTS), new Apply('type')], function($values) {
               return array_merge(['kind' => $values[0], 'parent' => $values[2], 'name' => $values[1]], $values[4]);
             }),
-            T_INTERFACE => new Returns(T_INTERFACE),
-            T_TRAIT     => new Returns(T_TRAIT)
+            T_INTERFACE => new Sequence([new Token(T_STRING), new Apply('type')], function($values) {
+              return array_merge(['kind' => $values[0], 'name' => $values[1]], $values[2]);
+            }),
+            T_TRAIT     => new Sequence([new Token(T_STRING), new Apply('type')], function($values) {
+              return array_merge(['kind' => $values[0], 'name' => $values[1]], $values[2]);
+            }),
           ])
         ],
         function($values) { return array_merge($values[2], ['modifiers' => $values[1], 'annotations' => $values[0]]); }

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -56,6 +56,7 @@ class ClassSyntax extends \text\parse\Syntax {
       'decl' => new Sequence(
         [
           new Optional(new Apply('annotations')),
+          new Apply('modifiers'),
           new Match([
             T_CLASS     => new Sequence([new Token(T_STRING), new Tokens(T_STRING, T_NS_SEPARATOR, T_EXTENDS, T_IMPLEMENTS), new Apply('type')], function($values) {
               return array_merge(['kind' => $values[0], 'name' => $values[1]], $values[3]);
@@ -64,7 +65,7 @@ class ClassSyntax extends \text\parse\Syntax {
             T_TRAIT     => new Returns(T_TRAIT)
           ])
         ],
-        function($values) { return array_merge($values[1], ['annotations' => $values[0]]); }
+        function($values) { return array_merge($values[2], ['annotations' => $values[0]]); }
       ),
       'annotations' => new Sequence(
         [new Token('['), new Repeated(new Apply('annotation'), new Token(','), $collectAnnotations), new Token(']')],

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -58,14 +58,18 @@ class ClassSyntax extends \text\parse\Syntax {
           new Optional(new Apply('annotations')),
           new Apply('modifiers'),
           new Match([
-            T_CLASS     => new Sequence([new Token(T_STRING), new Tokens(T_STRING, T_NS_SEPARATOR, T_EXTENDS, T_IMPLEMENTS), new Apply('type')], function($values) {
-              return array_merge(['kind' => $values[0], 'name' => $values[1]], $values[3]);
+            T_CLASS     => new Sequence([new Token(T_STRING), new Optional(new Apply('parent')), new Tokens(T_STRING, T_NS_SEPARATOR, T_IMPLEMENTS), new Apply('type')], function($values) {
+              return array_merge(['kind' => $values[0], 'parent' => $values[2], 'name' => $values[1]], $values[4]);
             }),
             T_INTERFACE => new Returns(T_INTERFACE),
             T_TRAIT     => new Returns(T_TRAIT)
           ])
         ],
         function($values) { return array_merge($values[2], ['annotations' => $values[0]]); }
+      ),
+      'parent' => new Sequence(
+        [new Token(T_EXTENDS), $typeName],
+        function($values) { return implode('', $values[1]); }
       ),
       'annotations' => new Sequence(
         [new Token('['), new Repeated(new Apply('annotation'), new Token(','), $collectAnnotations), new Token(']')],

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -57,6 +57,7 @@ class ClassSyntax extends \text\parse\Syntax {
         [
           new Optional(new Apply('annotations')),
           new Apply('modifiers'),
+          new Returns(function($values, $source) { return $source->lastComment(); }),
           new Match([
             T_CLASS     => new Sequence([new Token(T_STRING), new Optional(new Apply('parent')), new Tokens(T_STRING, T_NS_SEPARATOR, T_IMPLEMENTS), new Apply('type')], function($values) {
               return array_merge(['kind' => $values[0], 'parent' => $values[2], 'name' => $values[1]], $values[4]);
@@ -69,7 +70,7 @@ class ClassSyntax extends \text\parse\Syntax {
             }),
           ])
         ],
-        function($values) { return array_merge($values[2], ['modifiers' => $values[1], 'annotations' => $values[0]]); }
+        function($values) { return array_merge($values[3], ['comment' => $values[2], 'modifiers' => $values[1], 'annotations' => $values[0]]); }
       ),
       'parent' => new Sequence(
         [new Token(T_EXTENDS), $typeName],

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -106,7 +106,7 @@ class ClassSyntax extends \text\parse\Syntax {
             return ['kind' => 'use', 'name' => implode('', $values[1])];
           }),
           T_CONST => new Sequence([new Token(T_STRING), new Token('='), new Apply('expr'), new Token(';')], function($values) {
-            return ['kind' => 'const', 'name' => $values[1]];
+            return ['kind' => 'const', 'name' => $values[1], 'value' => $values[3]];
           })
         ]),
         new Sequence(

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -62,13 +62,13 @@ class ClassSyntax extends \text\parse\Syntax {
           new Apply('modifiers'),
           new Match([
             T_CLASS     => new Sequence([new Token(T_STRING), new Optional(new Apply('parent')), new Optional(new Apply('implements')), new Apply('type')], function($values) {
-              return array_merge(['kind' => $values[0], 'parent' => $values[2], 'implements' => $values[3], 'name' => $values[1]], $values[4]);
+              return array_merge(['kind' => $values[0], 'name' => $values[1], 'parent' => $values[2], 'implements' => $values[3]], $values[4]);
             }),
-            T_INTERFACE => new Sequence([new Token(T_STRING), new Apply('type')], function($values) {
-              return array_merge(['kind' => $values[0], 'name' => $values[1]], $values[2]);
+            T_INTERFACE => new Sequence([new Token(T_STRING), new Optional(new Apply('parents')), new Apply('type')], function($values) {
+              return array_merge(['kind' => $values[0], 'name' => $values[1], 'parent' => null, 'implements' => $values[2]], $values[3]);
             }),
             T_TRAIT     => new Sequence([new Token(T_STRING), new Apply('type')], function($values) {
-              return array_merge(['kind' => $values[0], 'name' => $values[1]], $values[2]);
+              return array_merge(['kind' => $values[0], 'name' => $values[1], 'parent' => null], $values[2]);
             }),
           ])
         ],
@@ -77,6 +77,10 @@ class ClassSyntax extends \text\parse\Syntax {
       'parent' => new Sequence(
         [new Token(T_EXTENDS), $typeName],
         function($values) { return implode('', $values[1]); }
+      ),
+      'parents' => new Sequence(
+        [new Token(T_EXTENDS), new Repeated($typeName, new Token(','))],
+        function($values) { return array_map(function($e) { return implode('', $e); }, $values[1]); }
       ),
       'implements' => new Sequence(
         [new Token(T_IMPLEMENTS), new Repeated($typeName, new Token(','))],

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -43,11 +43,11 @@ class ClassSyntax extends \text\parse\Syntax {
         return new CodeUnit($values[1], $values[2], $values[3]);
       }),
       'package' => new Sequence([new Token(T_NAMESPACE), $typeName, new Token(';')], function($values) {
-        return strtr(implode('', $values[1]), '\\', '.');
+        return implode('', $values[1]);
       }),
       'import' => new Match([
         T_USE => new Sequence([$typeName, new Token(';')], function($values) {
-          return strtr(implode('', $values[1]), '\\', '.');
+          return implode('', $values[1]);
         }),
         T_NEW => new Sequence([new Token(T_STRING), new Token('('), new Token(T_CONSTANT_ENCAPSED_STRING), new Token(')'), new Token(';')], function($values) {
           return trim($values[3], '\'"');

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -59,8 +59,8 @@ class ClassSyntax extends \text\parse\Syntax {
           new Optional(new Apply('annotations')),
           new Apply('modifiers'),
           new Match([
-            T_CLASS     => new Sequence([new Token(T_STRING), new Optional(new Apply('parent')), new Tokens(T_STRING, T_NS_SEPARATOR, T_IMPLEMENTS), new Apply('type')], function($values) {
-              return array_merge(['kind' => $values[0], 'parent' => $values[2], 'name' => $values[1]], $values[4]);
+            T_CLASS     => new Sequence([new Token(T_STRING), new Optional(new Apply('parent')), new Optional(new Apply('implements')), new Apply('type')], function($values) {
+              return array_merge(['kind' => $values[0], 'parent' => $values[2], 'implements' => $values[3], 'name' => $values[1]], $values[4]);
             }),
             T_INTERFACE => new Sequence([new Token(T_STRING), new Apply('type')], function($values) {
               return array_merge(['kind' => $values[0], 'name' => $values[1]], $values[2]);
@@ -75,6 +75,10 @@ class ClassSyntax extends \text\parse\Syntax {
       'parent' => new Sequence(
         [new Token(T_EXTENDS), $typeName],
         function($values) { return implode('', $values[1]); }
+      ),
+      'implements' => new Sequence(
+        [new Token(T_IMPLEMENTS), new Repeated($typeName, new Token(','))],
+        function($values) { return array_map(function($e) { return implode('', $e); }, $values[1]); }
       ),
       'annotations' => new Sequence(
         [new Token('['), new Repeated(new Apply('annotation'), new Token(','), $collectAnnotations), new Token(']')],

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -102,6 +102,9 @@ class ClassSyntax extends \text\parse\Syntax {
       ),
       'member' => new OneOf([
         new Match([
+          T_USE   => new Sequence([$typeName, new Token(';')], function($values) {
+            return ['kind' => 'use', 'name' => implode('', $values[1])];
+          }),
           T_CONST => new Sequence([new Token(T_STRING), new Token('='), new Apply('expr'), new Token(';')], function($values) {
             return ['kind' => 'const', 'name' => $values[1]];
           })

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -209,8 +209,8 @@ class ClassSyntax extends \text\parse\Syntax {
    * @return lang.mirrors.parse.CodeUnit
    */
   public function codeUnitOf($class) {
-   $dotted= strtr($class, '\\', '.');
-   if (!isset(self::$cache[$dotted])) {
+    $dotted= strtr($class, '\\', '.');
+    if (!isset(self::$cache[$dotted])) {
       self::$cache[$dotted]= $this->parse(new ClassSource($dotted));
       while (sizeof(self::$cache) > self::CACHE_LIMIT) {
         unset(self::$cache[key(self::$cache)]);

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -108,7 +108,7 @@ class ClassSyntax extends \text\parse\Syntax {
       ),
       'member' => new OneOf([
         new Match([
-          T_USE   => new Sequence([$typeName, new Token(';')], function($values) {
+          T_USE   => new Sequence([$typeName, new Apply('aliases')], function($values) {
             return ['kind' => 'use', 'name' => implode('', $values[1])];
           }),
           T_CONST => new Sequence([new Token(T_STRING), new Token('='), new Apply('expr'), new Token(';')], function($values) {
@@ -144,6 +144,7 @@ class ClassSyntax extends \text\parse\Syntax {
         ],
         function($values) { return ['name' => substr($values[3], 1), 'type' => $values[0] ? implode('', $values[0]) : null, 'ref' => isset($values[2]), 'var' => isset($values[1]), 'default' => $values[4]]; }
       ),
+      'aliases' => new Match([';' => null, '{' => new Block(true)]), 
       'method' => new Match([';' => null, '{' => new Block(true)]),
       'expr' => new OneOf([
         new Match([

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -113,7 +113,7 @@ class ClassSyntax extends \text\parse\Syntax {
               ),
               T_VARIABLE => new Sequence(
                 [new Optional(new Sequence([new Token('='), new Apply('expr')], function($values) { return $values[1]; })), new Match([',' => null, ';' => null])],
-                function($values) { return ['kind' => 'field', 'name' => $values[0], 'init' => $values[2]]; }
+                function($values) { return ['kind' => 'field', 'name' => substr($values[0], 1), 'init' => $values[2]]; }
               ),
             ])
           ],

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -65,7 +65,7 @@ class ClassSyntax extends \text\parse\Syntax {
             T_TRAIT     => new Returns(T_TRAIT)
           ])
         ],
-        function($values) { return array_merge($values[2], ['annotations' => $values[0]]); }
+        function($values) { return array_merge($values[2], ['modifiers' => $values[1], 'annotations' => $values[0]]); }
       ),
       'parent' => new Sequence(
         [new Token(T_EXTENDS), $typeName],

--- a/src/main/php/lang/mirrors/parse/ReferenceTypeRef.class.php
+++ b/src/main/php/lang/mirrors/parse/ReferenceTypeRef.class.php
@@ -29,7 +29,7 @@ class ReferenceTypeRef extends Resolveable {
    * @return var
    */
   public function resolve($type) {
-    return new XPClass($type->resolve($this->name)->reflect);
+    return XPClass::forName($type->resolve($this->name)->name());
   }
 
   /**

--- a/src/test/php/lang/mirrors/unittest/AbstractMemberFixture.class.php
+++ b/src/test/php/lang/mirrors/unittest/AbstractMemberFixture.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\mirrors\unittest;
 
 abstract class AbstractMemberFixture {
+  const INHERITED= 0;
   public $inheritedField;
 
   public function inheritedMethod() { }

--- a/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/AnnotationSyntaxTest.class.php
@@ -91,7 +91,7 @@ class AnnotationSyntaxTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  ['function() { }', [], ''],
-  #  ['function($a) { }', [['name' => '$a', 'type' => null, 'ref' => false, 'default' => null]], '']
+  #  ['function($a) { }', [['name' => 'a', 'type' => null, 'ref' => false, 'var' => false, 'default' => null]], '']
   #])]
   public function annotation_with_closures($literal, $signature, $code) {
     $this->assertEquals(

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -86,8 +86,8 @@ class ClassSyntaxTest extends \unittest\TestCase {
   public function test_class() {
     $this->assertEquals(
       new CodeUnit(
-        'de.thekid.test',
-        ['util.Objects'],
+        'de\thekid\test',
+        ['util\Objects'],
         [
           'kind'        => 'class',
           'name'        => 'IntegrationTest',

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -19,7 +19,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function object_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'name' => 'Object', 'modifiers' => [], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Object', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php class Object { }')
     );
   }
@@ -29,6 +29,14 @@ class ClassSyntaxTest extends \unittest\TestCase {
     $this->assertEquals(
       new CodeUnit(null, [], ['kind' => 'interface', 'comment' => null, 'name' => 'Serializable', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php interface Serializable { }')
+    );
+  }
+
+  #[@test]
+  public function runnable_impl() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => ['Runnable'], 'name' => 'Test', 'modifiers' => [], 'annotations' => null]),
+      $this->parse('<?php class Test implements Runnable { }')
     );
   }
 
@@ -43,7 +51,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function abstract_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),
       $this->parse('<?php abstract class Test { }')
     );
   }
@@ -51,7 +59,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function final_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'name' => 'Test', 'modifiers' => ['final'], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => ['final'], 'annotations' => null]),
       $this->parse('<?php final class Test { }')
     );
   }
@@ -59,7 +67,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function documented_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'comment' => '/** Doc */', 'parent' => null, 'name' => 'Test', 'modifiers' => [], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => '/** Doc */', 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php /** Doc */ class Test { }')
     );
   }
@@ -74,6 +82,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
           'kind'        => 'class',
           'name'        => 'IntegrationTest',
           'parent'      => '\unittest\TestCase',
+          'implements'  => null,
           'modifiers'   => [],
           'comment'     => null, 
           'annotations' => null,

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -19,7 +19,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function object_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'name' => 'Object', 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Object', 'annotations' => null]),
       $this->parse('<?php class Object { }')
     );
   }
@@ -33,6 +33,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
         [
           'kind'        => 'class',
           'name'        => 'IntegrationTest',
+          'parent'      => '\unittest\TestCase',
           'annotations' => null,
           'field' => [
             '$fixture' => [

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -126,10 +126,11 @@ class ClassSyntaxTest extends \unittest\TestCase {
               'kind'        => 'method',
               'name'        => 'connect',
               'params'      => [[
-                'name'    => '$arg',
+                'name'    => 'arg',
                 'type'    => null,
                 'ref'     => false,
-                'default' => null,
+                'var'     => false,
+                'default' => null
               ]],
               'access'      => ['private'],
               'annotations' => ['$arg' => ['inject' => new Value('db')]]

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -161,4 +161,27 @@ class ClassSyntaxTest extends \unittest\TestCase {
       ')
     );
   }
+
+  #[@test]
+  public function compact_field_syntax() {
+    $this->assertEquals(
+      [
+        'a' => [
+          'kind'        => 'field',
+          'name'        => 'a',
+          'init'        => null,
+          'access'      => ['private'],
+          'annotations' => null
+        ],
+        'b' => [
+          'kind'        => 'field',
+          'name'        => 'b',
+          'init'        => null,
+          'access'      => [],
+          'annotations' => null
+        ]
+      ],
+      $this->parse('<?php class Test { private $a, $b; }')->declaration()['field']
+    );
+  }
 }

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -19,8 +19,24 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function object_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Object', 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Object', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php class Object { }')
+    );
+  }
+
+  #[@test]
+  public function abstract_class() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),
+      $this->parse('<?php abstract class Test { }')
+    );
+  }
+
+  #[@test]
+  public function final_class() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Test', 'modifiers' => ['final'], 'annotations' => null]),
+      $this->parse('<?php final class Test { }')
     );
   }
 
@@ -34,6 +50,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
           'kind'        => 'class',
           'name'        => 'IntegrationTest',
           'parent'      => '\unittest\TestCase',
+          'modifiers'   => [],
           'annotations' => null,
           'field' => [
             '$fixture' => [

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -25,10 +25,26 @@ class ClassSyntaxTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function serializable_interface() {
+  public function interface_without_parent() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'interface', 'comment' => null, 'name' => 'Serializable', 'modifiers' => [], 'annotations' => null]),
-      $this->parse('<?php interface Serializable { }')
+      new CodeUnit(null, [], ['kind' => 'interface', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'A', 'modifiers' => [], 'annotations' => null]),
+      $this->parse('<?php interface A { }')
+    );
+  }
+
+  #[@test]
+  public function interface_with_parent() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'interface', 'comment' => null, 'parent' => null, 'implements' => ['B'], 'name' => 'A', 'modifiers' => [], 'annotations' => null]),
+      $this->parse('<?php interface A extends B { }')
+    );
+  }
+
+  #[@test]
+  public function interface_with_multiple_parents() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'interface', 'comment' => null, 'parent' => null, 'implements' => ['B', 'C'], 'name' => 'A', 'modifiers' => [], 'annotations' => null]),
+      $this->parse('<?php interface A extends B, C { }')
     );
   }
 
@@ -43,7 +59,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function creation_trait() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'trait', 'comment' => null, 'name' => 'Creation', 'modifiers' => [], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'trait', 'comment' => null, 'parent' => null, 'name' => 'Creation', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php trait Creation { }')
     );
   }

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -25,6 +25,22 @@ class ClassSyntaxTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function serializable_interface() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'interface', 'name' => 'Serializable', 'modifiers' => [], 'annotations' => null]),
+      $this->parse('<?php interface Serializable { }')
+    );
+  }
+
+  #[@test]
+  public function creation_trait() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'trait', 'name' => 'Creation', 'modifiers' => [], 'annotations' => null]),
+      $this->parse('<?php trait Creation { }')
+    );
+  }
+
+  #[@test]
   public function abstract_class() {
     $this->assertEquals(
       new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -19,7 +19,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function object_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Object', 'modifiers' => [], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'name' => 'Object', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php class Object { }')
     );
   }
@@ -27,7 +27,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function serializable_interface() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'interface', 'name' => 'Serializable', 'modifiers' => [], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'interface', 'comment' => null, 'name' => 'Serializable', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php interface Serializable { }')
     );
   }
@@ -35,7 +35,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function creation_trait() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'trait', 'name' => 'Creation', 'modifiers' => [], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'trait', 'comment' => null, 'name' => 'Creation', 'modifiers' => [], 'annotations' => null]),
       $this->parse('<?php trait Creation { }')
     );
   }
@@ -43,7 +43,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function abstract_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),
       $this->parse('<?php abstract class Test { }')
     );
   }
@@ -51,7 +51,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
   #[@test]
   public function final_class() {
     $this->assertEquals(
-      new CodeUnit(null, [], ['kind' => 'class', 'parent' => null, 'name' => 'Test', 'modifiers' => ['final'], 'annotations' => null]),
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'name' => 'Test', 'modifiers' => ['final'], 'annotations' => null]),
       $this->parse('<?php final class Test { }')
     );
   }
@@ -67,6 +67,7 @@ class ClassSyntaxTest extends \unittest\TestCase {
           'name'        => 'IntegrationTest',
           'parent'      => '\unittest\TestCase',
           'modifiers'   => [],
+          'comment'     => null, 
           'annotations' => null,
           'field' => [
             '$fixture' => [

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -75,6 +75,29 @@ class ClassSyntaxTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function class_using_trait_with_alias() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => [], 'annotations' => null, 'use' => [
+        'Creation' => ['kind' => 'use', 'name' => 'Creation']
+      ]]),
+      $this->parse('<?php class Test { use Creation { value as name; } }')
+    );
+  }
+
+  #[@test]
+  public function class_using_trait_with_aliases() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => [], 'annotations' => null, 'use' => [
+        'Creation' => ['kind' => 'use', 'name' => 'Creation']
+      ]]),
+      $this->parse('<?php class Test { use Creation {
+        a as b;
+        c as d;
+      } }')
+    );
+  }
+
+  #[@test]
   public function abstract_class() {
     $this->assertEquals(
       new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -78,9 +78,9 @@ class ClassSyntaxTest extends \unittest\TestCase {
           'comment'     => null, 
           'annotations' => null,
           'field' => [
-            '$fixture' => [
+            'fixture' => [
               'kind'        => 'field',
-              'name'        => '$fixture',
+              'name'        => 'fixture',
               'init'        => null,
               'access'      => ['private'],
               'annotations' => null

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -49,6 +49,16 @@ class ClassSyntaxTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function creation_user() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => [], 'annotations' => null, 'use' => [
+        'Creation' => ['kind' => 'use', 'name' => 'Creation']
+      ]]),
+      $this->parse('<?php class Test { use Creation; }')
+    );
+  }
+
+  #[@test]
   public function abstract_class() {
     $this->assertEquals(
       new CodeUnit(null, [], ['kind' => 'class', 'comment' => null, 'parent' => null, 'implements' => null, 'name' => 'Test', 'modifiers' => ['abstract'], 'annotations' => null]),

--- a/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ClassSyntaxTest.class.php
@@ -57,6 +57,14 @@ class ClassSyntaxTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function documented_class() {
+    $this->assertEquals(
+      new CodeUnit(null, [], ['kind' => 'class', 'comment' => '/** Doc */', 'parent' => null, 'name' => 'Test', 'modifiers' => [], 'annotations' => null]),
+      $this->parse('<?php /** Doc */ class Test { }')
+    );
+  }
+
+  #[@test]
   public function test_class() {
     $this->assertEquals(
       new CodeUnit(

--- a/src/test/php/lang/mirrors/unittest/FieldTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/FieldTest.class.php
@@ -4,6 +4,7 @@ use lang\mirrors\Field;
 use lang\mirrors\Modifiers;
 use lang\mirrors\TypeMirror;
 use lang\IllegalArgumentException;
+use lang\ElementNotFoundException;
 
 class FieldTest extends AbstractFieldTest {
 
@@ -20,7 +21,7 @@ class FieldTest extends AbstractFieldTest {
     new Field($this->type, new \ReflectionProperty(self::class, 'fixture'));
   }
 
-  #[@test, @expect(IllegalArgumentException::class)]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function constructor_raises_exception_if_field_does_not_exist() {
     new Field($this->type, 'not.a.field');
   }

--- a/src/test/php/lang/mirrors/unittest/FixtureBase.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureBase.class.php
@@ -1,4 +1,5 @@
 <?php namespace lang\mirrors\unittest;
 
 class FixtureBase implements FixtureInterface {
+  use FixtureTrait;
 }

--- a/src/test/php/lang/mirrors/unittest/FixtureBase.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureBase.class.php
@@ -1,0 +1,4 @@
+<?php namespace lang\mirrors\unittest;
+
+class FixtureBase implements FixtureInterface {
+}

--- a/src/test/php/lang/mirrors/unittest/FixtureCloseable.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureCloseable.class.php
@@ -1,0 +1,4 @@
+<?php namespace lang\mirrors\unittest;
+
+interface FixtureCloseable extends FixtureInterface, \lang\Closeable {
+}

--- a/src/test/php/lang/mirrors/unittest/FixtureImpl.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureImpl.class.php
@@ -1,4 +1,4 @@
 <?php namespace lang\mirrors\unittest;
 
-abstract class FixtureImpl extends FixtureBase implements \lang\Runnable {
+abstract class FixtureImpl extends FixtureBase implements \lang\Closeable {
 }

--- a/src/test/php/lang/mirrors/unittest/FixtureImpl.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureImpl.class.php
@@ -1,0 +1,4 @@
+<?php namespace lang\mirrors\unittest;
+
+abstract class FixtureImpl extends FixtureBase implements \lang\Runnable {
+}

--- a/src/test/php/lang/mirrors/unittest/FixtureParams.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureParams.class.php
@@ -1,0 +1,41 @@
+<?php namespace lang\mirrors\unittest;
+
+use lang\Type;
+
+class FixtureParams extends \lang\Object {
+  const CONSTANT = 'Test';
+
+  private function noParam() { }
+
+  private function oneParam($arg) { }
+
+  private function oneOptionalParam($arg= null) { }
+
+  private function oneConstantOptionalParam($arg= self::CONSTANT) { }
+
+  private function oneArrayOptionalParam($arg= [1, 2, 3]) { }
+
+  private function oneVariadicParam(... $arg) { }
+
+  private function oneTypeHintedParam(Type $arg) { }
+
+  private function oneSelfTypeHintedParam(self $arg) { }
+
+  private function oneArrayTypeHintedParam(array $arg) { }
+
+  private function oneCallableTypeHintedParam(callable $arg) { }
+
+  /** @param lang.Type */
+  private function oneDocumentedTypeParam($arg) { }
+
+  /**
+   * Fixture
+   *
+   * @param lang.Type $a
+   * @param var $b
+   */
+  private function twoDocumentedTypeParams($a, $b) { }
+
+  #[@$arg: test]
+  private function oneAnnotatedParam($arg) { }
+}

--- a/src/test/php/lang/mirrors/unittest/FixtureTrait.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureTrait.class.php
@@ -1,4 +1,6 @@
 <?php namespace lang\mirrors\unittest;
 
 trait FixtureTrait {
+  private $traitField;
+  private function traitMethod() { }
 }

--- a/src/test/php/lang/mirrors/unittest/FixtureUsed.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureUsed.class.php
@@ -1,0 +1,4 @@
+<?php namespace lang\mirrors\unittest;
+
+trait FixtureUsed {
+}

--- a/src/test/php/lang/mirrors/unittest/FixtureUses.class.php
+++ b/src/test/php/lang/mirrors/unittest/FixtureUses.class.php
@@ -1,0 +1,5 @@
+<?php namespace lang\mirrors\unittest;
+
+class FixtureUses extends FixtureBase {
+  use FixtureUsed;
+}

--- a/src/test/php/lang/mirrors/unittest/FromCodeTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/FromCodeTest.class.php
@@ -1,0 +1,16 @@
+<?php namespace lang\mirrors\unittest;
+
+use lang\mirrors\Sources;
+
+class FromCodeTest extends SourceTest {
+
+  /**
+   * Creates a new reflection source
+   *
+   * @param  string $name
+   * @return lang.mirrors.Source
+   */
+  protected function reflect($name) {
+    return Sources::$CODE->reflect($name);
+  }
+}

--- a/src/test/php/lang/mirrors/unittest/FromReflectionTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/FromReflectionTest.class.php
@@ -1,0 +1,16 @@
+<?php namespace lang\mirrors\unittest;
+
+use lang\mirrors\Sources;
+
+class FromReflectionTest extends SourceTest {
+
+  /**
+   * Creates a new reflection source
+   *
+   * @param  string $name
+   * @return lang.mirrors.Source
+   */
+  protected function reflect($name) {
+    return Sources::$REFLECTION->reflect($name);
+  }
+}

--- a/src/test/php/lang/mirrors/unittest/MemberFixture.class.php
+++ b/src/test/php/lang/mirrors/unittest/MemberFixture.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\mirrors\unittest;
 
 class MemberFixture extends AbstractMemberFixture {
+  use FixtureTrait;
   const CONSTANT= 1;
 
   public $publicInstanceField;

--- a/src/test/php/lang/mirrors/unittest/MemberFixture.class.php
+++ b/src/test/php/lang/mirrors/unittest/MemberFixture.class.php
@@ -1,6 +1,8 @@
 <?php namespace lang\mirrors\unittest;
 
 class MemberFixture extends AbstractMemberFixture {
+  const CONSTANT= 1;
+
   public $publicInstanceField;
   protected $protectedInstanceField;
   private $privateInstanceField;

--- a/src/test/php/lang/mirrors/unittest/MethodTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/MethodTest.class.php
@@ -5,6 +5,7 @@ use lang\mirrors\Modifiers;
 use lang\mirrors\TypeMirror;
 use lang\IllegalArgumentException;
 use lang\IllegalAccessException;
+use lang\ElementNotFoundException;
 
 class MethodTest extends AbstractMethodTest {
 
@@ -33,7 +34,7 @@ class MethodTest extends AbstractMethodTest {
     new Method($this->type, new \ReflectionMethod(self::class, __FUNCTION__));
   }
 
-  #[@test, @expect(IllegalArgumentException::class)]
+  #[@test, @expect(ElementNotFoundException::class)]
   public function constructor_raises_exception_if_method_does_not_exist() {
     new Method($this->type, 'not.a.method');
   }

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -12,41 +12,6 @@ use lang\ClassLoader;
 
 class ParameterTest extends \unittest\TestCase {
   private static $type= null;
-  const CONSTANT= 'Test';
-
-  private function noParam() { }
-
-  private function oneParam($arg) { }
-
-  private function oneOptionalParam($arg= null) { }
-
-  private function oneConstantOptionalParam($arg= self::CONSTANT) { }
-
-  private function oneArrayOptionalParam($arg= [1, 2, 3]) { }
-
-  private function oneVariadicParam(... $arg) { }
-
-  private function oneTypeHintedParam(Type $arg) { }
-
-  private function oneSelfTypeHintedParam(self $arg) { }
-
-  private function oneArrayTypeHintedParam(array $arg) { }
-
-  private function oneCallableTypeHintedParam(callable $arg) { }
-
-  /** @param lang.Type */
-  private function oneDocumentedTypeParam($arg) { }
-
-  /**
-   * Fixture
-   *
-   * @param var $a
-   * @param lang.Type $b
-   */
-  private function twoDocumentedTypeParams($a, $b) { }
-
-  #[@$arg: test]
-  private function oneAnnotatedParam($arg) { }
 
   /**
    * Creates a new parameter
@@ -57,9 +22,9 @@ class ParameterTest extends \unittest\TestCase {
   private function newFixture($method, $num) {
     if (null === self::$type) {
       if (NotOnHHVM::runtime()) {
-        self::$type= new TypeMirror(self::class);
+        self::$type= new TypeMirror(FixtureParams::class);
       } else {
-        $class= ClassLoader::defineClass('ParameterTestWithTypedVariadic', self::class, [], '{
+        $class= ClassLoader::defineClass('FixtureParamsWithTypedVariadic', FixtureParams::class, [], '{
           private function oneVariadicTypedParam(Type... $arg) { }
         }');
         self::$type= new TypeMirror($class);
@@ -71,14 +36,14 @@ class ParameterTest extends \unittest\TestCase {
 
   #[@test]
   public function can_create_from_method_and_offset() {
-    new Parameter(new Method(new TypeMirror(self::class), 'oneParam'), 0);
+    new Parameter(new Method(new TypeMirror(FixtureParams::class), 'oneParam'), 0);
   }
 
   #[@test]
   public function can_create_from_method_and_parameter() {
     new Parameter(
-      new Method(new TypeMirror(self::class), 'oneParam'),
-      new \ReflectionParameter([__CLASS__, 'oneParam'], 0)
+      new Method(new TypeMirror(FixtureParams::class), 'oneParam'),
+      new \ReflectionParameter([FixtureParams::class, 'oneParam'], 0)
     );
   }
 
@@ -127,7 +92,7 @@ class ParameterTest extends \unittest\TestCase {
 
   #[@test]
   public function self_type_hint() {
-    $this->assertEquals(typeof($this), $this->newFixture('oneSelfTypeHintedParam', 0)->type());
+    $this->assertEquals(new XPClass(FixtureParams::class), $this->newFixture('oneSelfTypeHintedParam', 0)->type());
   }
 
   #[@test, @action(new NotOnHHVM())]
@@ -152,7 +117,7 @@ class ParameterTest extends \unittest\TestCase {
 
   #[@test]
   public function documented_type_hint_using_long_form() {
-    $this->assertEquals(new XPClass(Type::class), $this->newFixture('twoDocumentedTypeParams', 1)->type());
+    $this->assertEquals(new XPClass(Type::class), $this->newFixture('twoDocumentedTypeParams', 0)->type());
   }
 
   #[@test, @expect(IllegalStateException::class), @values([
@@ -170,7 +135,7 @@ class ParameterTest extends \unittest\TestCase {
 
   #[@test]
   public function constant_default_value_for_optional() {
-    $this->assertEquals(self::CONSTANT, $this->newFixture('oneConstantOptionalParam', 0)->defaultValue());
+    $this->assertEquals(FixtureParams::CONSTANT, $this->newFixture('oneConstantOptionalParam', 0)->defaultValue());
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -114,4 +114,29 @@ abstract class SourceTest extends \unittest\TestCase {
   public function typeKind_of_interface() {
     $this->assertEquals(Kind::$INTERFACE, $this->reflect(FixtureInterface::class)->typeKind());
   }
+
+  #[@test]
+  public function has_instance_method() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasMethod('publicInstanceMethod'));
+  }
+
+  #[@test]
+  public function has_static_method() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasMethod('publicClassMethod'));
+  }
+
+  #[@test]
+  public function has_instance_field() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasField('publicInstanceField'));
+  }
+
+  #[@test]
+  public function has_static_field() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasField('publicClassField'));
+  }
+
+  #[@test]
+  public function has_constant() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasConstant('CONSTANT'));
+  }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -64,6 +64,16 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function typeModifiers_of_final() {
+    $this->assertEquals(new Modifiers('public final'), $this->reflect(FixtureFinal::class)->typeModifiers());
+  }
+
+  #[@test]
+  public function typeModifiers_of_enum() {
+    $this->assertEquals(new Modifiers('public'), $this->reflect(FixtureEnum::class)->typeModifiers());
+  }
+
+  #[@test]
   public function typeModifiers_of_interface() {
     $this->assertEquals(new Modifiers('public'), $this->reflect(FixtureInterface::class)->typeModifiers());
   }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\mirrors\unittest;
 
+#[@fixture]
 abstract class SourceTest extends \unittest\TestCase {
 
   /**
@@ -33,5 +34,15 @@ abstract class SourceTest extends \unittest\TestCase {
   #[@test]
   public function typeParent_of_parentless_class() {
     $this->assertNull($this->reflect(AbstractMemberFixture::class)->typeParent());
+  }
+
+  #[@test]
+  public function typeAnnotations_of_this_class() {
+    $this->assertEquals([null => ['fixture' => null]], $this->reflect(self::class)->typeAnnotations());
+  }
+
+  #[@test]
+  public function typeAnnotations_of_annotationless_class() {
+    $this->assertNull($this->reflect(AbstractMemberFixture::class)->typeAnnotations());
   }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -3,6 +3,8 @@
 use lang\mirrors\Modifiers;
 use lang\mirrors\Kind;
 use lang\Closeable;
+use lang\XPClass;
+use lang\Type;
 
 /**
  * Base class for source implementation testing
@@ -304,6 +306,70 @@ abstract class SourceTest extends \unittest\TestCase {
       'inheritedMethod',
       $this->reflect(MemberFixture::class)->methodNamed('inheritedMethod')['name']
     );
+  }
+
+  #[@test]
+  public function no_params() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('noParam');
+    $this->assertEquals([], $method['params']());
+  }
+
+  #[@test]
+  public function one_param() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('oneParam');
+    $param= $method['params']()[0];
+    $this->assertEquals(
+      [0, 'arg', null, false, false, null],
+      [$param['pos'], $param['name'], $param['type'], $param['ref'], $param['var'], $param['default']]
+    );
+  }
+
+  #[@test]
+  public function one_optional_param() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('oneOptionalParam');
+    $param= $method['params']()[0];
+    $this->assertEquals(
+      [0, 'arg', null, false, false, null],
+      [$param['pos'], $param['name'], $param['type'], $param['ref'], $param['var'], $param['default']()]
+    );
+  }
+
+  #[@test]
+  public function one_variadic_param() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('oneVariadicParam');
+    $param= $method['params']()[0];
+    $this->assertEquals(
+      [0, 'arg', null, false, true, null],
+      [$param['pos'], $param['name'], $param['type'], $param['ref'], $param['var'], $param['default']]
+    );
+  }
+
+  #[@test]
+  public function typed_param() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('oneTypeHintedParam');
+    $param= $method['params']()[0];
+    $this->assertEquals(new XPClass(Type::class), $param['type']());
+  }
+
+  #[@test]
+  public function self_typehinted_param() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('oneSelfTypeHintedParam');
+    $param= $method['params']()[0];
+    $this->assertEquals(new XPClass(FixtureParams::class), $param['type']());
+  }
+
+  #[@test]
+  public function array_typehinted_param() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('oneArrayTypeHintedParam');
+    $param= $method['params']()[0];
+    $this->assertEquals(Type::$ARRAY, $param['type']());
+  }
+
+  #[@test]
+  public function callable_typehinted_param() {
+    $method= $this->reflect(FixtureParams::class)->methodNamed('oneCallableTypeHintedParam');
+    $param= $method['params']()[0];
+    $this->assertEquals(Type::$CALLABLE, $param['type']());
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -5,6 +5,7 @@ use lang\mirrors\Kind;
 use lang\Closeable;
 use lang\XPClass;
 use lang\Type;
+use lang\ElementNotFoundException;
 
 /**
  * Base class for source implementation testing
@@ -243,6 +244,11 @@ abstract class SourceTest extends \unittest\TestCase {
     );
   }
 
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function non_existant_field() {
+    $this->reflect(MemberFixture::class)->fieldNamed('does.not.exist');
+  }
+
   #[@test]
   public function has_instance_method() {
     $this->assertTrue($this->reflect(MemberFixture::class)->hasMethod('publicInstanceMethod'));
@@ -306,6 +312,11 @@ abstract class SourceTest extends \unittest\TestCase {
       'inheritedMethod',
       $this->reflect(MemberFixture::class)->methodNamed('inheritedMethod')['name']
     );
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function non_existant_method() {
+    $this->reflect(MemberFixture::class)->methodNamed('does.not.exist');
   }
 
   #[@test]
@@ -383,6 +394,11 @@ abstract class SourceTest extends \unittest\TestCase {
       ['CONSTANT' => MemberFixture::CONSTANT, 'INHERITED' => MemberFixture::INHERITED],
       iterator_to_array($this->reflect(MemberFixture::class)->allConstants())
     );
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function non_existant_constant() {
+    $this->reflect(MemberFixture::class)->constantNamed('does.not.exist');
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -14,6 +14,18 @@ use lang\ElementNotFoundException;
 abstract class SourceTest extends \unittest\TestCase {
 
   /**
+   * Returns the keys of an iterator on a map sorted alphabetically
+   *
+   * @param  php.Traversable $iterator
+   * @return lang.mirrors.Field[]
+   */
+  private function sorted($iterator) {
+    $keys= array_keys(iterator_to_array($iterator));
+    sort($keys);
+    return $keys;
+  }
+
+  /**
    * Creates a new reflection source
    *
    * @param  string $name
@@ -126,23 +138,26 @@ abstract class SourceTest extends \unittest\TestCase {
 
   #[@test]
   public function all_interfaces() {
-    $names= array_keys(iterator_to_array($this->reflect(FixtureImpl::class)->allInterfaces()));
-    sort($names);
-    $this->assertEquals([Closeable::class, FixtureInterface::class], $names);
+    $this->assertEquals(
+      [Closeable::class, FixtureInterface::class],
+      $this->sorted($this->reflect(FixtureImpl::class)->allInterfaces())
+    );
   }
 
   #[@test]
   public function declared_interfaces() {
-    $names= array_keys(iterator_to_array($this->reflect(FixtureImpl::class)->declaredInterfaces()));
-    sort($names);
-    $this->assertEquals([Closeable::class], $names);
+    $this->assertEquals(
+      [Closeable::class],
+      $this->sorted($this->reflect(FixtureImpl::class)->declaredInterfaces())
+    );
   }
 
   #[@test]
   public function parent_interfaces() {
-    $names= array_keys(iterator_to_array($this->reflect(FixtureCloseable::class)->allInterfaces()));
-    sort($names);
-    $this->assertEquals([Closeable::class, FixtureInterface::class], $names);
+    $this->assertEquals(
+      [Closeable::class, FixtureInterface::class],
+      $this->sorted($this->reflect(FixtureCloseable::class)->allInterfaces())
+    );
   }
 
   #[@test]
@@ -152,16 +167,18 @@ abstract class SourceTest extends \unittest\TestCase {
 
   #[@test]
   public function all_traits() {
-    $names= array_keys(iterator_to_array($this->reflect(FixtureUses::class)->allTraits()));
-    sort($names);
-    $this->assertEquals([FixtureTrait::class, FixtureUsed::class], $names);
+    $this->assertEquals(
+      [FixtureTrait::class, FixtureUsed::class],
+      $this->sorted($this->reflect(FixtureUses::class)->allTraits())
+    );
   }
 
   #[@test]
   public function declared_traits() {
-    $names= array_keys(iterator_to_array($this->reflect(FixtureUses::class)->declaredTraits()));
-    sort($names);
-    $this->assertEquals([FixtureUsed::class], $names);
+    $this->assertEquals(
+      [FixtureUsed::class],
+      $this->sorted($this->reflect(FixtureUses::class)->declaredTraits())
+    );
   }
 
   #[@test]
@@ -198,16 +215,16 @@ abstract class SourceTest extends \unittest\TestCase {
   public function all_fields() {
     $this->assertEquals(
       [
-        'publicInstanceField',
-        'protectedInstanceField',
-        'privateInstanceField',
-        'publicClassField',
-        'protectedClassField',
-        'privateClassField',
         'inheritedField',
+        'privateClassField',
+        'privateInstanceField',
+        'protectedClassField',
+        'protectedInstanceField',
+        'publicClassField',
+        'publicInstanceField',
         'traitField'
       ],
-      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->allFields()))
+      $this->sorted($this->reflect(MemberFixture::class)->allFields())
     );
   }
 
@@ -215,15 +232,15 @@ abstract class SourceTest extends \unittest\TestCase {
   public function declared_fields() {
     $this->assertEquals(
       [
-        'publicInstanceField',
-        'protectedInstanceField',
-        'privateInstanceField',
-        'publicClassField',
-        'protectedClassField',
         'privateClassField',
+        'privateInstanceField',
+        'protectedClassField',
+        'protectedInstanceField',
+        'publicClassField',
+        'publicInstanceField',
         'traitField'
       ],
-      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->declaredFields()))
+      $this->sorted($this->reflect(MemberFixture::class)->declaredFields())
     );
   }
 
@@ -231,7 +248,7 @@ abstract class SourceTest extends \unittest\TestCase {
   public function trait_fields() {
     $this->assertEquals(
       ['traitField'],
-      array_keys(iterator_to_array($this->reflect(FixtureTrait::class)->allFields()))
+      $this->sorted($this->reflect(FixtureTrait::class)->allFields())
     );
   }
 
@@ -278,16 +295,16 @@ abstract class SourceTest extends \unittest\TestCase {
   public function all_methods() {
     $this->assertEquals(
       [
-        'publicInstanceMethod',
-        'protectedInstanceMethod',
-        'privateInstanceMethod',
-        'publicClassMethod',
-        'protectedClassMethod',
-        'privateClassMethod',
         'inheritedMethod',
+        'privateClassMethod',
+        'privateInstanceMethod',
+        'protectedClassMethod',
+        'protectedInstanceMethod',
+        'publicClassMethod',
+        'publicInstanceMethod',
         'traitMethod'
       ],
-      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->allMethods()))
+      $this->sorted($this->reflect(MemberFixture::class)->allMethods())
     );
   }
 
@@ -295,15 +312,15 @@ abstract class SourceTest extends \unittest\TestCase {
   public function declared_methods() {
     $this->assertEquals(
       [
-        'publicInstanceMethod',
-        'protectedInstanceMethod',
-        'privateInstanceMethod',
-        'publicClassMethod',
-        'protectedClassMethod',
         'privateClassMethod',
+        'privateInstanceMethod',
+        'protectedClassMethod',
+        'protectedInstanceMethod',
+        'publicClassMethod',
+        'publicInstanceMethod',
         'traitMethod'
       ],
-      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->declaredMethods()))
+      $this->sorted($this->reflect(MemberFixture::class)->declaredMethods())
     );
   }
 

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -139,4 +139,20 @@ abstract class SourceTest extends \unittest\TestCase {
   public function has_constant() {
     $this->assertTrue($this->reflect(MemberFixture::class)->hasConstant('CONSTANT'));
   }
+
+  #[@test]
+  public function fields() {
+    $this->assertEquals(
+      [
+        'publicInstanceField',
+        'protectedInstanceField',
+        'privateInstanceField',
+        'publicClassField',
+        'protectedClassField',
+        'privateClassField',
+        'inheritedField'
+      ],
+      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->allFields()))
+    );
+  }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -21,6 +21,11 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function packageName() {
+    $this->assertEquals('lang.mirrors.unittest', $this->reflect(self::class)->packageName());
+  }
+
+  #[@test]
   public function typeParent_of_this_class() {
     $this->assertEquals($this->reflect(parent::class), $this->reflect(self::class)->typeParent());
   }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -3,6 +3,9 @@
 use lang\mirrors\Modifiers;
 use lang\mirrors\Kind;
 
+/**
+ * Base class for source implementation testing
+ */
 #[@fixture]
 abstract class SourceTest extends \unittest\TestCase {
 
@@ -22,6 +25,14 @@ abstract class SourceTest extends \unittest\TestCase {
   #[@test]
   public function typeDeclaration() {
     $this->assertEquals('SourceTest', $this->reflect(self::class)->typeDeclaration());
+  }
+
+  #[@test]
+  public function typeComment() {
+    $this->assertEquals(
+      "/**\n * Base class for source implementation testing\n */",
+      $this->reflect(self::class)->typeComment()
+    );
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -36,6 +36,11 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function typeComment_for_undocumented_class() {
+    $this->assertNull($this->reflect(FixtureTrait::class)->typeComment());
+  }
+
+  #[@test]
   public function packageName() {
     $this->assertEquals('lang.mirrors.unittest', $this->reflect(self::class)->packageName());
   }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -14,4 +14,19 @@ abstract class SourceTest extends \unittest\TestCase {
   public function typeName() {
     $this->assertEquals('lang.mirrors.unittest.SourceTest', $this->reflect(self::class)->typeName());
   }
+
+  #[@test]
+  public function typeDeclaration() {
+    $this->assertEquals('SourceTest', $this->reflect(self::class)->typeDeclaration());
+  }
+
+  #[@test]
+  public function typeParent_of_this_class() {
+    $this->assertEquals($this->reflect(parent::class), $this->reflect(self::class)->typeParent());
+  }
+
+  #[@test]
+  public function typeParent_of_parentless_class() {
+    $this->assertNull($this->reflect(AbstractMemberFixture::class)->typeParent());
+  }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -116,18 +116,13 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function has_instance_method() {
-    $this->assertTrue($this->reflect(MemberFixture::class)->hasMethod('publicInstanceMethod'));
-  }
-
-  #[@test]
-  public function has_static_method() {
-    $this->assertTrue($this->reflect(MemberFixture::class)->hasMethod('publicClassMethod'));
-  }
-
-  #[@test]
   public function has_instance_field() {
     $this->assertTrue($this->reflect(MemberFixture::class)->hasField('publicInstanceField'));
+  }
+
+  #[@test]
+  public function has_inherited_field() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasField('inheritedField'));
   }
 
   #[@test]
@@ -141,7 +136,7 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function fields() {
+  public function all_fields() {
     $this->assertEquals(
       [
         'publicInstanceField',
@@ -153,6 +148,110 @@ abstract class SourceTest extends \unittest\TestCase {
         'inheritedField'
       ],
       array_keys(iterator_to_array($this->reflect(MemberFixture::class)->allFields()))
+    );
+  }
+
+  #[@test]
+  public function declared_fields() {
+    $this->assertEquals(
+      [
+        'publicInstanceField',
+        'protectedInstanceField',
+        'privateInstanceField',
+        'publicClassField',
+        'protectedClassField',
+        'privateClassField'
+      ],
+      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->declaredFields()))
+    );
+  }
+
+  #[@test]
+  public function instance_field() {
+    $this->assertEquals(
+      'publicInstanceField',
+      $this->reflect(MemberFixture::class)->fieldNamed('publicInstanceField')['name']
+    );
+  }
+
+  #[@test]
+  public function static_field() {
+    $this->assertEquals(
+      'publicClassField',
+      $this->reflect(MemberFixture::class)->fieldNamed('publicClassField')['name']
+    );
+  }
+
+  #[@test]
+  public function inherited_field() {
+    $this->assertEquals(
+      'inheritedField',
+      $this->reflect(MemberFixture::class)->fieldNamed('inheritedField')['name']
+    );
+  }
+
+  #[@test]
+  public function has_instance_method() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasMethod('publicInstanceMethod'));
+  }
+
+  #[@test]
+  public function has_static_method() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasMethod('publicClassMethod'));
+  }
+
+  #[@test]
+  public function all_methods() {
+    $this->assertEquals(
+      [
+        'publicInstanceMethod',
+        'protectedInstanceMethod',
+        'privateInstanceMethod',
+        'publicClassMethod',
+        'protectedClassMethod',
+        'privateClassMethod',
+        'inheritedMethod'
+      ],
+      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->allMethods()))
+    );
+  }
+
+  #[@test]
+  public function declared_methods() {
+    $this->assertEquals(
+      [
+        'publicInstanceMethod',
+        'protectedInstanceMethod',
+        'privateInstanceMethod',
+        'publicClassMethod',
+        'protectedClassMethod',
+        'privateClassMethod'
+      ],
+      array_keys(iterator_to_array($this->reflect(MemberFixture::class)->declaredMethods()))
+    );
+  }
+
+  #[@test]
+  public function instance_method() {
+    $this->assertEquals(
+      'publicInstanceMethod',
+      $this->reflect(MemberFixture::class)->methodNamed('publicInstanceMethod')['name']
+    );
+  }
+
+  #[@test]
+  public function static_method() {
+    $this->assertEquals(
+      'publicClassMethod',
+      $this->reflect(MemberFixture::class)->methodNamed('publicClassMethod')['name']
+    );
+  }
+
+  #[@test]
+  public function inherited_method() {
+    $this->assertEquals(
+      'inheritedMethod',
+      $this->reflect(MemberFixture::class)->methodNamed('inheritedMethod')['name']
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -117,6 +117,11 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function typeImplements() {
+    $this->assertTrue($this->reflect(FixtureImpl::class)->typeImplements(FixtureInterface::class));
+  }
+
+  #[@test]
   public function all_interfaces() {
     $names= array_keys(iterator_to_array($this->reflect(FixtureImpl::class)->allInterfaces()));
     sort($names);
@@ -131,8 +136,22 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function typeImplements() {
-    $this->assertTrue($this->reflect(FixtureImpl::class)->typeImplements(FixtureInterface::class));
+  public function typeUses() {
+    $this->assertTrue($this->reflect(FixtureImpl::class)->typeUses(FixtureTrait::class));
+  }
+
+  #[@test]
+  public function all_traits() {
+    $names= array_keys(iterator_to_array($this->reflect(FixtureUses::class)->allTraits()));
+    sort($names);
+    $this->assertEquals([FixtureTrait::class, FixtureUsed::class], $names);
+  }
+
+  #[@test]
+  public function declared_traits() {
+    $names= array_keys(iterator_to_array($this->reflect(FixtureUses::class)->declaredTraits()));
+    sort($names);
+    $this->assertEquals([FixtureUsed::class], $names);
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\mirrors\unittest;
 
 use lang\mirrors\Modifiers;
+use lang\mirrors\Kind;
 
 #[@fixture]
 abstract class SourceTest extends \unittest\TestCase {
@@ -76,5 +77,25 @@ abstract class SourceTest extends \unittest\TestCase {
   #[@test]
   public function typeModifiers_of_interface() {
     $this->assertEquals(new Modifiers('public'), $this->reflect(FixtureInterface::class)->typeModifiers());
+  }
+
+  #[@test]
+  public function typeKind() {
+    $this->assertEquals(Kind::$CLASS, $this->reflect(self::class)->typeKind());
+  }
+
+  #[@test]
+  public function typeKind_of_trait() {
+    $this->assertEquals(Kind::$TRAIT, $this->reflect(FixtureTrait::class)->typeKind());
+  }
+
+  #[@test]
+  public function typeKind_of_enum() {
+    $this->assertEquals(Kind::$ENUM, $this->reflect(FixtureEnum::class)->typeKind());
+  }
+
+  #[@test]
+  public function typeKind_of_interface() {
+    $this->assertEquals(Kind::$INTERFACE, $this->reflect(FixtureInterface::class)->typeKind());
   }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -185,6 +185,11 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function has_trait_field() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasField('traitField'));
+  }
+
+  #[@test]
   public function has_static_field() {
     $this->assertTrue($this->reflect(MemberFixture::class)->hasField('publicClassField'));
   }
@@ -199,7 +204,8 @@ abstract class SourceTest extends \unittest\TestCase {
         'publicClassField',
         'protectedClassField',
         'privateClassField',
-        'inheritedField'
+        'inheritedField',
+        'traitField'
       ],
       array_keys(iterator_to_array($this->reflect(MemberFixture::class)->allFields()))
     );
@@ -214,9 +220,18 @@ abstract class SourceTest extends \unittest\TestCase {
         'privateInstanceField',
         'publicClassField',
         'protectedClassField',
-        'privateClassField'
+        'privateClassField',
+        'traitField'
       ],
       array_keys(iterator_to_array($this->reflect(MemberFixture::class)->declaredFields()))
+    );
+  }
+
+  #[@test]
+  public function trait_fields() {
+    $this->assertEquals(
+      ['traitField'],
+      array_keys(iterator_to_array($this->reflect(FixtureTrait::class)->allFields()))
     );
   }
 
@@ -269,7 +284,8 @@ abstract class SourceTest extends \unittest\TestCase {
         'publicClassMethod',
         'protectedClassMethod',
         'privateClassMethod',
-        'inheritedMethod'
+        'inheritedMethod',
+        'traitMethod'
       ],
       array_keys(iterator_to_array($this->reflect(MemberFixture::class)->allMethods()))
     );
@@ -284,7 +300,8 @@ abstract class SourceTest extends \unittest\TestCase {
         'privateInstanceMethod',
         'publicClassMethod',
         'protectedClassMethod',
-        'privateClassMethod'
+        'privateClassMethod',
+        'traitMethod'
       ],
       array_keys(iterator_to_array($this->reflect(MemberFixture::class)->declaredMethods()))
     );

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\mirrors\unittest;
 
+use lang\mirrors\Modifiers;
+
 #[@fixture]
 abstract class SourceTest extends \unittest\TestCase {
 
@@ -44,5 +46,10 @@ abstract class SourceTest extends \unittest\TestCase {
   #[@test]
   public function typeAnnotations_of_annotationless_class() {
     $this->assertNull($this->reflect(AbstractMemberFixture::class)->typeAnnotations());
+  }
+
+  #[@test]
+  public function typeModifiers() {
+    $this->assertEquals(new Modifiers('public abstract'), $this->reflect(self::class)->typeModifiers());
   }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -180,11 +180,6 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function has_constant() {
-    $this->assertTrue($this->reflect(MemberFixture::class)->hasConstant('CONSTANT'));
-  }
-
-  #[@test]
   public function all_fields() {
     $this->assertEquals(
       [
@@ -302,5 +297,41 @@ abstract class SourceTest extends \unittest\TestCase {
       'inheritedMethod',
       $this->reflect(MemberFixture::class)->methodNamed('inheritedMethod')['name']
     );
+  }
+
+  #[@test]
+  public function has_constant() {
+    $this->assertTrue($this->reflect(MemberFixture::class)->hasConstant('CONSTANT'));
+  }
+
+  #[@test]
+  public function all_constants() {
+    $this->assertEquals(
+      ['CONSTANT' => MemberFixture::CONSTANT, 'INHERITED' => MemberFixture::INHERITED],
+      iterator_to_array($this->reflect(MemberFixture::class)->allConstants())
+    );
+  }
+
+  #[@test]
+  public function constant_named() {
+    $this->assertEquals(
+      MemberFixture::CONSTANT,
+      $this->reflect(MemberFixture::class)->constantNamed('CONSTANT')
+    );
+  }
+
+  #[@test]
+  public function isSubtypeOf_returns_false_for_self() {
+    $this->assertFalse($this->reflect(FixtureImpl::class)->isSubtypeOf(FixtureImpl::class));
+  }
+
+  #[@test]
+  public function isSubtypeOf_parent() {
+    $this->assertTrue($this->reflect(FixtureImpl::class)->isSubtypeOf(FixtureBase::class));
+  }
+
+  #[@test]
+  public function isSubtypeOf_implemented_interface() {
+    $this->assertTrue($this->reflect(FixtureImpl::class)->isSubtypeOf(FixtureInterface::class));
   }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -52,4 +52,19 @@ abstract class SourceTest extends \unittest\TestCase {
   public function typeModifiers() {
     $this->assertEquals(new Modifiers('public abstract'), $this->reflect(self::class)->typeModifiers());
   }
+
+  #[@test]
+  public function typeModifiers_of_trait() {
+    $this->assertEquals(new Modifiers('public abstract'), $this->reflect(FixtureTrait::class)->typeModifiers());
+  }
+
+  #[@test]
+  public function typeModifiers_of_abstract() {
+    $this->assertEquals(new Modifiers('public abstract'), $this->reflect(FixtureAbstract::class)->typeModifiers());
+  }
+
+  #[@test]
+  public function typeModifiers_of_interface() {
+    $this->assertEquals(new Modifiers('public'), $this->reflect(FixtureInterface::class)->typeModifiers());
+  }
 }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\Modifiers;
 use lang\mirrors\Kind;
+use lang\Runnable;
 
 /**
  * Base class for source implementation testing
@@ -113,6 +114,25 @@ abstract class SourceTest extends \unittest\TestCase {
   #[@test]
   public function typeKind_of_interface() {
     $this->assertEquals(Kind::$INTERFACE, $this->reflect(FixtureInterface::class)->typeKind());
+  }
+
+  #[@test]
+  public function all_interfaces() {
+    $names= array_keys(iterator_to_array($this->reflect(FixtureImpl::class)->allInterfaces()));
+    sort($names);
+    $this->assertEquals([Runnable::class, FixtureInterface::class], $names);
+  }
+
+  #[@test]
+  public function declared_interfaces() {
+    $names= array_keys(iterator_to_array($this->reflect(FixtureImpl::class)->declaredInterfaces()));
+    sort($names);
+    $this->assertEquals([Runnable::class], $names);
+  }
+
+  #[@test]
+  public function typeImplements() {
+    $this->assertTrue($this->reflect(FixtureImpl::class)->typeImplements(FixtureInterface::class));
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -1,0 +1,17 @@
+<?php namespace lang\mirrors\unittest;
+
+abstract class SourceTest extends \unittest\TestCase {
+
+  /**
+   * Creates a new reflection source
+   *
+   * @param  string $name
+   * @return lang.mirrors.Source
+   */
+  protected abstract function reflect($name);
+
+  #[@test]
+  public function typeName() {
+    $this->assertEquals('lang.mirrors.unittest.SourceTest', $this->reflect(self::class)->typeName());
+  }
+}

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\mirrors\Modifiers;
 use lang\mirrors\Kind;
-use lang\Runnable;
+use lang\Closeable;
 
 /**
  * Base class for source implementation testing
@@ -125,14 +125,21 @@ abstract class SourceTest extends \unittest\TestCase {
   public function all_interfaces() {
     $names= array_keys(iterator_to_array($this->reflect(FixtureImpl::class)->allInterfaces()));
     sort($names);
-    $this->assertEquals([Runnable::class, FixtureInterface::class], $names);
+    $this->assertEquals([Closeable::class, FixtureInterface::class], $names);
   }
 
   #[@test]
   public function declared_interfaces() {
     $names= array_keys(iterator_to_array($this->reflect(FixtureImpl::class)->declaredInterfaces()));
     sort($names);
-    $this->assertEquals([Runnable::class], $names);
+    $this->assertEquals([Closeable::class], $names);
+  }
+
+  #[@test]
+  public function parent_interfaces() {
+    $names= array_keys(iterator_to_array($this->reflect(FixtureCloseable::class)->allInterfaces()));
+    sort($names);
+    $this->assertEquals([Closeable::class, FixtureInterface::class], $names);
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -116,6 +116,16 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function with_constructor() {
+    $this->assertEquals('__construct', $this->reflect(self::class)->constructor()['name']);
+  }
+
+  #[@test]
+  public function default_constructor() {
+    $this->assertEquals('__default', $this->reflect(MemberFixture::class)->constructor()['name']);
+  }
+
+  #[@test]
   public function has_instance_field() {
     $this->assertTrue($this->reflect(MemberFixture::class)->hasField('publicInstanceField'));
   }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
@@ -8,6 +8,18 @@ use lang\ElementNotFoundException;
 class TypeMirrorFieldsTest extends \unittest\TestCase {
   private $fixture;
 
+  /**
+   * Returns the elements of an iterator on Field instances sorted by name
+   *
+   * @param  php.Traversable $iterator
+   * @return lang.mirrors.Field[]
+   */
+  private function sorted($iterator) {
+    $list= iterator_to_array($iterator);
+    usort($list, function($a, $b) { return strcmp($a->name(), $b->name()); });
+    return $list;
+  }
+
   public function setUp() {
     $this->fixture= new TypeMirror(MemberFixture::class);
   }
@@ -36,16 +48,16 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function all_fields() {
     $this->assertEquals(
       [
-        new Field($this->fixture, 'publicInstanceField'),
-        new Field($this->fixture, 'protectedInstanceField'),
-        new Field($this->fixture, 'privateInstanceField'),
-        new Field($this->fixture, 'publicClassField'),
-        new Field($this->fixture, 'protectedClassField'),
-        new Field($this->fixture, 'privateClassField'),
         new Field($this->fixture, 'inheritedField'),
+        new Field($this->fixture, 'privateClassField'),
+        new Field($this->fixture, 'privateInstanceField'),
+        new Field($this->fixture, 'protectedClassField'),
+        new Field($this->fixture, 'protectedInstanceField'),
+        new Field($this->fixture, 'publicClassField'),
+        new Field($this->fixture, 'publicInstanceField'),
         new Field($this->fixture, 'traitField')
       ],
-      iterator_to_array($this->fixture->fields())
+      $this->sorted($this->fixture->fields())
     );
   }
 
@@ -53,15 +65,15 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function declared_fields() {
     $this->assertEquals(
       [
-        new Field($this->fixture, 'publicInstanceField'),
-        new Field($this->fixture, 'protectedInstanceField'),
-        new Field($this->fixture, 'privateInstanceField'),
-        new Field($this->fixture, 'publicClassField'),
-        new Field($this->fixture, 'protectedClassField'),
         new Field($this->fixture, 'privateClassField'),
+        new Field($this->fixture, 'privateInstanceField'),
+        new Field($this->fixture, 'protectedClassField'),
+        new Field($this->fixture, 'protectedInstanceField'),
+        new Field($this->fixture, 'publicClassField'),
+        new Field($this->fixture, 'publicInstanceField'),
         new Field($this->fixture, 'traitField')
       ],
-      iterator_to_array($this->fixture->fields()->declared())
+      $this->sorted($this->fixture->fields()->declared())
     );
   }
 
@@ -69,13 +81,13 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function instance_fields() {
     $this->assertEquals(
       [
-        new Field($this->fixture, 'publicInstanceField'),
-        new Field($this->fixture, 'protectedInstanceField'),
-        new Field($this->fixture, 'privateInstanceField'),
         new Field($this->fixture, 'inheritedField'),
+        new Field($this->fixture, 'privateInstanceField'),
+        new Field($this->fixture, 'protectedInstanceField'),
+        new Field($this->fixture, 'publicInstanceField'),
         new Field($this->fixture, 'traitField')
       ],
-      iterator_to_array($this->fixture->fields()->of(Member::$INSTANCE))
+      $this->sorted($this->fixture->fields()->of(Member::$INSTANCE))
     );
   }
 
@@ -83,11 +95,11 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function static_fields() {
     $this->assertEquals(
       [
-        new Field($this->fixture, 'publicClassField'),
+        new Field($this->fixture, 'privateClassField'),
         new Field($this->fixture, 'protectedClassField'),
-        new Field($this->fixture, 'privateClassField')
+        new Field($this->fixture, 'publicClassField')
       ],
-      iterator_to_array($this->fixture->fields()->of(Member::$STATIC))
+      $this->sorted($this->fixture->fields()->of(Member::$STATIC))
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
@@ -42,7 +42,8 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
         new Field($this->fixture, 'publicClassField'),
         new Field($this->fixture, 'protectedClassField'),
         new Field($this->fixture, 'privateClassField'),
-        new Field($this->fixture, 'inheritedField')
+        new Field($this->fixture, 'inheritedField'),
+        new Field($this->fixture, 'traitField')
       ],
       iterator_to_array($this->fixture->fields())
     );
@@ -57,7 +58,8 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
         new Field($this->fixture, 'privateInstanceField'),
         new Field($this->fixture, 'publicClassField'),
         new Field($this->fixture, 'protectedClassField'),
-        new Field($this->fixture, 'privateClassField')
+        new Field($this->fixture, 'privateClassField'),
+        new Field($this->fixture, 'traitField')
       ],
       iterator_to_array($this->fixture->fields()->declared())
     );
@@ -70,7 +72,8 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
         new Field($this->fixture, 'publicInstanceField'),
         new Field($this->fixture, 'protectedInstanceField'),
         new Field($this->fixture, 'privateInstanceField'),
-        new Field($this->fixture, 'inheritedField')
+        new Field($this->fixture, 'inheritedField'),
+        new Field($this->fixture, 'traitField')
       ],
       iterator_to_array($this->fixture->fields()->of(Member::$INSTANCE))
     );

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
@@ -47,7 +47,8 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
         new Method($this->fixture, 'publicClassMethod'),
         new Method($this->fixture, 'protectedClassMethod'),
         new Method($this->fixture, 'privateClassMethod'),
-        new Method($this->fixture, 'inheritedMethod')
+        new Method($this->fixture, 'inheritedMethod'),
+        new Method($this->fixture, 'traitMethod')
       ],
       iterator_to_array($this->fixture->methods())
     );
@@ -62,7 +63,8 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
         new Method($this->fixture, 'privateInstanceMethod'),
         new Method($this->fixture, 'publicClassMethod'),
         new Method($this->fixture, 'protectedClassMethod'),
-        new Method($this->fixture, 'privateClassMethod')
+        new Method($this->fixture, 'privateClassMethod'),
+        new Method($this->fixture, 'traitMethod')
       ],
       iterator_to_array($this->fixture->methods()->declared())
     );
@@ -75,7 +77,8 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
         new Method($this->fixture, 'publicInstanceMethod'),
         new Method($this->fixture, 'protectedInstanceMethod'),
         new Method($this->fixture, 'privateInstanceMethod'),
-        new Method($this->fixture, 'inheritedMethod')
+        new Method($this->fixture, 'inheritedMethod'),
+        new Method($this->fixture, 'traitMethod')
       ],
       iterator_to_array($this->fixture->methods()->of(Member::$INSTANCE))
     );

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
@@ -8,6 +8,18 @@ use lang\ElementNotFoundException;
 class TypeMirrorMethodsTest extends \unittest\TestCase {
   private $fixture;
 
+  /**
+   * Returns the elements of an iterator on Method instances sorted by name
+   *
+   * @param  php.Traversable $iterator
+   * @return lang.mirrors.Method[]
+   */
+  private function sorted($iterator) {
+    $list= iterator_to_array($iterator);
+    usort($list, function($a, $b) { return strcmp($a->name(), $b->name()); });
+    return $list;
+  }
+
   public function setUp() {
     $this->fixture= new TypeMirror(MemberFixture::class);
   }
@@ -41,16 +53,16 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   public function all_methods() {
     $this->assertEquals(
       [
-        new Method($this->fixture, 'publicInstanceMethod'),
-        new Method($this->fixture, 'protectedInstanceMethod'),
-        new Method($this->fixture, 'privateInstanceMethod'),
-        new Method($this->fixture, 'publicClassMethod'),
-        new Method($this->fixture, 'protectedClassMethod'),
-        new Method($this->fixture, 'privateClassMethod'),
         new Method($this->fixture, 'inheritedMethod'),
+        new Method($this->fixture, 'privateClassMethod'),
+        new Method($this->fixture, 'privateInstanceMethod'),
+        new Method($this->fixture, 'protectedClassMethod'),
+        new Method($this->fixture, 'protectedInstanceMethod'),
+        new Method($this->fixture, 'publicClassMethod'),
+        new Method($this->fixture, 'publicInstanceMethod'),
         new Method($this->fixture, 'traitMethod')
       ],
-      iterator_to_array($this->fixture->methods())
+      $this->sorted($this->fixture->methods())
     );
   }
 
@@ -58,15 +70,15 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   public function declared_methods() {
     $this->assertEquals(
       [
-        new Method($this->fixture, 'publicInstanceMethod'),
-        new Method($this->fixture, 'protectedInstanceMethod'),
-        new Method($this->fixture, 'privateInstanceMethod'),
-        new Method($this->fixture, 'publicClassMethod'),
-        new Method($this->fixture, 'protectedClassMethod'),
         new Method($this->fixture, 'privateClassMethod'),
+        new Method($this->fixture, 'privateInstanceMethod'),
+        new Method($this->fixture, 'protectedClassMethod'),
+        new Method($this->fixture, 'protectedInstanceMethod'),
+        new Method($this->fixture, 'publicClassMethod'),
+        new Method($this->fixture, 'publicInstanceMethod'),
         new Method($this->fixture, 'traitMethod')
       ],
-      iterator_to_array($this->fixture->methods()->declared())
+      $this->sorted($this->fixture->methods()->declared())
     );
   }
 
@@ -74,13 +86,13 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   public function instance_methods() {
     $this->assertEquals(
       [
-        new Method($this->fixture, 'publicInstanceMethod'),
-        new Method($this->fixture, 'protectedInstanceMethod'),
-        new Method($this->fixture, 'privateInstanceMethod'),
         new Method($this->fixture, 'inheritedMethod'),
+        new Method($this->fixture, 'privateInstanceMethod'),
+        new Method($this->fixture, 'protectedInstanceMethod'),
+        new Method($this->fixture, 'publicInstanceMethod'),
         new Method($this->fixture, 'traitMethod')
       ],
-      iterator_to_array($this->fixture->methods()->of(Member::$INSTANCE))
+      $this->sorted($this->fixture->methods()->of(Member::$INSTANCE))
     );
   }
 
@@ -88,11 +100,11 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   public function static_methods() {
     $this->assertEquals(
       [
-        new Method($this->fixture, 'publicClassMethod'),
+        new Method($this->fixture, 'privateClassMethod'),
         new Method($this->fixture, 'protectedClassMethod'),
-        new Method($this->fixture, 'privateClassMethod')
+        new Method($this->fixture, 'publicClassMethod')
       ],
-      iterator_to_array($this->fixture->methods()->of(Member::$STATIC))
+      $this->sorted($this->fixture->methods()->of(Member::$STATIC))
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\mirrors\unittest;
 
 use lang\mirrors\TypeMirror;
+use lang\mirrors\Sources;
 use lang\mirrors\Package;
 use lang\mirrors\Modifiers;
 use lang\ElementNotFoundException;
@@ -15,6 +16,16 @@ class TypeMirrorTest extends TestCase {
   #[@test]
   public function can_create() {
     new TypeMirror(self::class);
+  }
+
+  #[@test]
+  public function can_create_from_reflection() {
+    new TypeMirror(self::class, Sources::$REFLECTION);
+  }
+
+  #[@test]
+  public function can_create_from_parsed() {
+    new TypeMirror(self::class, Sources::$CODE);
   }
 
   #[@test]


### PR DESCRIPTION
This pull request extracts the actual reflection to a new interface, `lang.mirrors.Source`, implements the current functionality in `lang.mirrors.FromReflection`, adds a new `lang.mirrors.FromCode` source and adds caching to the parsed code units.

## API
```php
public interface lang.mirrors.Source {
  lang.mirrors.parse.CodeUnit codeUnit()
  string typeName()
  string packageName()
  string typeDeclaration()
  self typeParent()
  string typeComment()
  [:var] typeAnnotations()
  lang.mirrors.Modifiers typeModifiers()
  lang.mirrors.Kind typeKind()
  bool isSubtypeOf(string $class)
  bool typeImplements(string $name)
  bool typeUses(string $name)
  php.Generator declaredInterfaces()
  php.Generator allTraits()
  php.Generator declaredTraits()
  var constructor()
  php.Generator allFields()
  php.Generator declaredFields()
  php.Generator allMethods()
  php.Generator declaredMethods()
  php.Generator allConstants()
  php.Generator allInterfaces()
  lang.Generic newInstance(var[] $args) throws lang.IllegalArgumentException, ...
  bool hasField(string $name)
  bool hasMethod(string $name)
  bool hasConstant(string $name)
  var fieldNamed(string $name) throws lang.ElementNotFoundException
  var methodNamed(string $name) throws lang.ElementNotFoundException
  var constantNamed(string $name) throws lang.ElementNotFoundException
  self resolve(string $name)
}

```

## TODOs
* [x] Declaration, package
* [x] Class parent
* [x] Implemented interfaces
* [x] Type inheritance
* [x] Interface parents
* [x] Used traits
* [x] Constructor
* [x] Fields
* [x] Methods
* [x] Parameters
* [x] Constants