### PR TITLE
Add type union support

### DIFF
--- a/src/main/php/lang/mirrors/parse/TagsSource.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSource.class.php
@@ -34,7 +34,7 @@ class TagsSource extends \text\parse\Tokens {
    * @param  string $input
    */
   public function __construct($input) {
-    $this->tokens= new StringTokenizer($input, "@:()<>[], \t\n", true);
+    $this->tokens= new StringTokenizer($input, "@:()<>[]|, \t\n", true);
   }
 
   /** @return var */

--- a/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
@@ -37,12 +37,6 @@ class TagsSyntax extends \text\parse\Syntax {
           function($values) { return [$values[0] => $values[1]]; }
         )
       ]),
-      'braces' => new Match([
-        TagsSource::T_FUNCTION => new Sequence(
-          [new Token('('), new Repeated(new Apply('types'), new Token(',')), new Token(')'), new Token(':'), new Apply('type')],
-          function($values) { return new FunctionTypeRef([null] === $values[2] ? [] : $values[2], $values[5]); }
-        )
-      ]),
       'types' => new Sequence(
         [new Repeated(new Apply('type'), new Token('|'))],
         function($values) {
@@ -57,36 +51,37 @@ class TagsSyntax extends \text\parse\Syntax {
       ),
       'type' => new Sequence(
         [
-          new OneOf([
-            new Match([
-              TagsSource::T_STRING   => new Returns(new TypeRef(Primitive::$STRING)),
-              TagsSource::T_DOUBLE   => new Returns(new TypeRef(Primitive::$DOUBLE)),
-              TagsSource::T_INT      => new Returns(new TypeRef(Primitive::$INT)),
-              TagsSource::T_BOOL     => new Returns(new TypeRef(Primitive::$BOOL)),
-              TagsSource::T_VAR      => new Returns(new TypeRef(Type::$VAR)),
-              TagsSource::T_VOID     => new Returns(new TypeRef(Type::$VOID)),
-              TagsSource::T_CALLABLE => new Returns(new TypeRef(Type::$CALLABLE)),
-              TagsSource::T_ARRAY    => new Returns(new TypeRef(Type::$ARRAY)),
-              TagsSource::T_WORD     => new Sequence(
-                [new Optional(new Sequence(
-                  [new Token('<'), new Repeated(new Apply('types'), new Token(',')), new Token('>')],
-                  function($values) { return $values[1]; }
-                ))],
-                function($values) {
-                  $base= new ReferenceTypeRef($values[0]);
-                  return $values[1] ? new GenericTypeRef($base, $values[1]) : $base;
-                }
-              ),
-              '(' => new Sequence(
-                [new Apply('braces'), new Token(')')],
+          new Match([
+            TagsSource::T_STRING   => new Returns(new TypeRef(Primitive::$STRING)),
+            TagsSource::T_DOUBLE   => new Returns(new TypeRef(Primitive::$DOUBLE)),
+            TagsSource::T_INT      => new Returns(new TypeRef(Primitive::$INT)),
+            TagsSource::T_BOOL     => new Returns(new TypeRef(Primitive::$BOOL)),
+            TagsSource::T_VAR      => new Returns(new TypeRef(Type::$VAR)),
+            TagsSource::T_VOID     => new Returns(new TypeRef(Type::$VOID)),
+            TagsSource::T_CALLABLE => new Returns(new TypeRef(Type::$CALLABLE)),
+            TagsSource::T_ARRAY    => new Returns(new TypeRef(Type::$ARRAY)),
+            TagsSource::T_FUNCTION => new Sequence(
+              [new Token('('), new Repeated(new Apply('types'), new Token(',')), new Token(')'), new Token(':'), new Apply('type')],
+              function($values) { return new FunctionTypeRef([null] === $values[2] ? [] : $values[2], $values[5]); }
+            ),
+            TagsSource::T_WORD     => new Sequence(
+              [new Optional(new Sequence(
+                [new Token('<'), new Repeated(new Apply('types'), new Token(',')), new Token('>')],
                 function($values) { return $values[1]; }
-              ),
-              '[' => new Sequence(
-                [new Token(':'), new Apply('types'), new Token(']')],
-                function($values) { return new MapTypeRef($values[2]); }
-              )
-            ]),
-            new Apply('braces')
+              ))],
+              function($values) {
+                $base= new ReferenceTypeRef($values[0]);
+                return $values[1] ? new GenericTypeRef($base, $values[1]) : $base;
+              }
+            ),
+            '(' => new Sequence(
+              [new Apply('types'), new Token(')')],
+              function($values) { return $values[1]; }
+            ),
+            '[' => new Sequence(
+              [new Token(':'), new Apply('types'), new Token(']')],
+              function($values) { return new MapTypeRef($values[2]); }
+            )
           ]),
           new Repeated(new Sequence([new Token('['), new Token(']')], function() { return true; })),
         ],

--- a/src/main/php/lang/mirrors/parse/TypeUnionRef.class.php
+++ b/src/main/php/lang/mirrors/parse/TypeUnionRef.class.php
@@ -1,0 +1,43 @@
+<?php namespace lang\mirrors\parse;
+
+use lang\TypeUnion;
+use util\Objects;
+
+class TypeUnionRef extends Resolveable {
+  private $types;
+
+  /**
+   * Creates a new instance
+   *
+   * @param  lang.mirrors.parse.TypeRef[] $arguments
+   */
+  public function __construct($types) {
+    $this->types= $types;
+  }
+
+  /**
+   * Resolve this value 
+   *
+   * @param  lang.mirrors.Source $source
+   * @return var
+   */
+  public function resolve($type) {
+    return new TypeUnion(array_map(
+      function($arg) use($type) { return $arg->resolve($type); },
+      $this->types
+    ));
+  }
+
+  /**
+   * Returns whether a given value is equal to this code unit
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && Objects::equal($this->types, $cmp->types);
+  }
+
+  /** @return string */
+  public function __toString() { return Objects::stringOf($this->types); }
+}

--- a/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
@@ -111,6 +111,8 @@ class TagsSyntaxTest extends \unittest\TestCase {
   #[@test, @values([
   #  '@param string|int',
   #  '@param string|int The union',
+  #  '@param (string|int)',
+  #  '@param (string|int) The union',
   #  '@param string | int',
   #  '@param string | int The union'
   #])]

--- a/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
@@ -8,6 +8,7 @@ use lang\mirrors\parse\MapTypeRef;
 use lang\mirrors\parse\FunctionTypeRef;
 use lang\mirrors\parse\GenericTypeRef;
 use lang\mirrors\parse\ReferenceTypeRef;
+use lang\mirrors\parse\TypeUnionRef;
 use lang\Type;
 use lang\Primitive;
 
@@ -95,6 +96,19 @@ class TagsSyntaxTest extends \unittest\TestCase {
   #])]
   public function nested_type_parameters($declaration, $type) {
     $this->assertEquals(['param' => [$type]], $this->parse($declaration));
+  }
+
+  #[@test, @values([
+  #  '@param string|int',
+  #  '@param string|int The union',
+  #  '@param string | int',
+  #  '@param string | int The union'
+  #])]
+  public function union_type($declaration) {
+    $this->assertEquals(
+      ['param' => [new TypeUnionRef([new TypeRef(Primitive::$STRING), new TypeRef(Primitive::$INT)])]],
+      $this->parse($declaration)
+    );
   }
 
   #[@test, @values([


### PR DESCRIPTION
See discussion on https://github.com/xp-forge/mirrors/issues/13:

```sh
Timm@slate ~/devel/stubbles-core [master]
$ xp -cp ../xp/parse/src/main/php/ -cp ../xp/mirrors/src/main/php/ -w '
  require("vendor/autoload.php");
  $seq= new \lang\mirrors\TypeMirror("stubbles\\lang\\Sequence");
  return $seq->methods()->named("of")->parameters()->first()->type()
'
lang.TypeUnion<stubbles.lang.Sequence|php.Traversable|array>
```

Depends on https://github.com/xp-framework/core/pull/76