### PR TITLE
Add Parameter::declaringRoutine()

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ public class lang.mirrors.Method extends lang.mirrors.Routine {
 }
 
 public class lang.mirrors.Parameters extends lang.Object implements php.IteratorAggregate {
-  public __construct(lang.mirrors.Method $mirror, var $reflect)
+  public __construct(lang.mirrors.Routine $mirror, var $reflect)
 
   public bool present()
   public int length()
@@ -108,10 +108,11 @@ public class lang.mirrors.Parameters extends lang.Object implements php.Iterator
 }
 
 public class lang.mirrors.Parameter extends lang.Object {
-  public __construct(lang.mirrors.Method $mirror, var $reflect)
+  public __construct(lang.mirrors.Routine $mirror, var $reflect)
 
   public string name()
   public int position()
+  public lang.mirrors.Routine declaringRoutine()
   public bool isOptional()
   public bool isVariadic()
   public bool isVerified()

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -15,7 +15,7 @@ class Parameter extends \lang\Object {
   /**
    * Creates a new parameter
    *
-   * @param  lang.mirrors.Method $mirror
+   * @param  lang.mirrors.Routine $mirror
    * @param  var $arg Either a ReflectionParameter or an offset
    * @throws lang.IllegalArgumentException If there is no such parameter
    */
@@ -40,6 +40,9 @@ class Parameter extends \lang\Object {
 
   /** @return int */
   public function position() { return $this->reflect['pos']; }
+
+  /** @return lang.mirrors.Routine */
+  public function declaringRoutine() { return $this->mirror; }
 
   /** @return bool */
   public function isVariadic() { return $this->reflect['var']; }

--- a/src/main/php/lang/mirrors/Parameters.class.php
+++ b/src/main/php/lang/mirrors/Parameters.class.php
@@ -11,7 +11,7 @@ class Parameters extends \lang\Object implements \IteratorAggregate {
   /**
    * Creates a new parameters instance
    *
-   * @param  lang.mirrors.Method $mirror
+   * @param  lang.mirrors.Routine $mirror
    * @param  [:var] $reflect
    */
   public function __construct($mirror, $reflect) {

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -66,6 +66,14 @@ class ParameterTest extends \unittest\TestCase {
     $this->assertEquals(0, $this->newFixture('oneParam', 0)->position());
   }
 
+  #[@test]
+  public function declaringRoutine() {
+    $this->assertEquals(
+      new Method(self::$type, 'oneParam'),
+      $this->newFixture('oneParam', 0)->declaringRoutine()
+    );
+  }
+
   #[@test, @values([['oneOptionalParam', true], ['oneParam', false]])]
   public function isOptional($method, $result) {
     $this->assertEquals($result, $this->newFixture($method, 0)->isOptional());


### PR DESCRIPTION
This pull request opens a "way back" from `lang.mirrors.Parameter` instances to the routine (either a method or the constructor) they're declared on:

```php
Console::writeLine('The parameter ', $param->name(), ' belongs to ', $param->declaringRoutine());
```