### PR TITLE
Fix tests with opcache.save_comments=0

### DIFF
--- a/src/main/php/lang/mirrors/FromHHVMReflection.class.php
+++ b/src/main/php/lang/mirrors/FromHHVMReflection.class.php
@@ -5,6 +5,12 @@ use lang\mirrors\parse\Value;
 class FromHHVMReflection extends FromReflection {
   private $types;
 
+  /**
+   * Creates a new HHVM reflection source
+   *
+   * @param  php.ReflectionClass $reflect
+   * @param  lang.mirrors.Sources $source
+   */
   public function __construct(\ReflectionClass $reflect, Sources $source= null) {
     parent::__construct($reflect, $source);
     $this->types= new HackTypes($reflect);

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -21,6 +21,12 @@ class FromReflection extends \lang\Object implements Source {
     self::$RETAIN_COMMENTS= (bool)ini_get('opcache.save_comments');
   }
 
+  /**
+   * Creates a new reflection source
+   *
+   * @param  php.ReflectionClass $reflect
+   * @param  lang.mirrors.Sources $source
+   */
   public function __construct(\ReflectionClass $reflect, Sources $source= null) {
     $this->reflect= $reflect;
     $this->name= $reflect->name;


### PR DESCRIPTION
Fixes #18 by parsing sourcecode for doc comments if `opcache.save_comments=0`.