### PR TITLE
Add filtering for methods and fields

### DIFF
--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -16,8 +16,7 @@ class Fields extends Members {
    * @return bool
    */
   public function provides($name) {
-    if (0 === strncmp('__', $name, 2)) return false;
-    return $this->mirror->reflect->hasField($name);
+    return 0 === strncmp($name, '__', 2) ? false : $this->mirror->reflect->hasField($name);
   }
 
   /**
@@ -35,47 +34,37 @@ class Fields extends Members {
   }
 
   /**
-   * Iterates over all fields
+   * Iterates over fields.
    *
+   * @param  util.Filter $filter
    * @return php.Generator
    */
-  public function getIterator() {
-    foreach ($this->mirror->reflect->allFields() as $name => $field) {
+  public function all($filter= null) {
+    foreach ($this->mirror->reflect->allFields() as $name => $member) {
       if (0 === strncmp('__', $name, 2)) continue;
-      yield new Field($this->mirror, $field);
+      $field= new Field($this->mirror, $member);
+      if (null === $filter || $filter->accept($field)) yield $field;
     }
   }
 
   /**
    * Iterates over declared fields.
    *
-   * @return php.Generator
-   */
-  public function declared() {
-    foreach ($this->mirror->reflect->declaredFields() as $name => $field) {
-      if (0 === strncmp('__', $name, 2)) continue;
-      yield new Field($this->mirror, $field);
-    }
-  }
-
-  /**
-   * Iterates over methods and returns those matching a given filter
-   *
    * @param  util.Filter $filter
    * @return php.Generator
    */
-  public function select($filter) {
-    foreach ($this->mirror->reflect->allFields() as $name => $member) {
+  public function declared($filter= null) {
+    foreach ($this->mirror->reflect->declaredFields() as $name => $member) {
       if (0 === strncmp('__', $name, 2)) continue;
       $field= new Field($this->mirror, $member);
-      if ($filter->accept($field)) yield $field;
+      if (null === $filter || $filter->accept($field)) yield $field;
     }
   }
 
   /**
    * Iterates over fields.
    *
-   * @deprecated Use select() instead
+   * @deprecated Use all() or declared() instead
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
    * @return php.Generator
    */

--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -75,6 +75,7 @@ class Fields extends Members {
   /**
    * Iterates over fields.
    *
+   * @deprecated Use select() instead
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
    * @return php.Generator
    */

--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -2,17 +2,12 @@
 
 use lang\ElementNotFoundException;
 
-class Fields extends \lang\Object implements \IteratorAggregate {
-  private $mirror;
-
-  /**
-   * Creates a new methods instance
-   *
-   * @param  lang.mirrors.TypeMirror $mirror
-   */
-  public function __construct(TypeMirror $mirror) {
-    $this->mirror= $mirror;
-  }
+/**
+ * A type's fields 
+ *
+ * @test  xp://lang.mirrors.unittest.TypeMirrorFieldsTest
+ */
+class Fields extends Members {
 
   /**
    * Checks whether a given field is provided
@@ -64,6 +59,20 @@ class Fields extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
+   * Iterates over methods and returns those matching a given filter
+   *
+   * @param  util.Filter $filter
+   * @return php.Generator
+   */
+  public function select($filter) {
+    foreach ($this->mirror->reflect->allFields() as $name => $member) {
+      if (0 === strncmp('__', $name, 2)) continue;
+      $field= new Field($this->mirror, $member);
+      if ($filter->accept($field)) yield $field;
+    }
+  }
+
+  /**
    * Iterates over fields.
    *
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
@@ -79,18 +88,5 @@ class Fields extends \lang\Object implements \IteratorAggregate {
       if (0 === strncmp('__', $name, 2) || $instance === $field['access']->isStatic()) continue;
       yield new Field($this->mirror, $field);
     }
-  }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    $s= nameof($this)."@[\n";
-    foreach ($this as $field) {
-      $s.= '  '.(string)$field."\n";
-    }
-    return $s.']';
   }
 }

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -7,7 +7,7 @@ use lang\mirrors\parse\TagsSource;
  * Base class for all type members: Fields, methods, constructors.
  */
 abstract class Member extends \lang\Object {
-  public static $STATIC= 0x0001, $INSTANCE= 0x0002, $DECLARED= 0x0004;
+  public static $STATIC= 0x0001, $INSTANCE= 0x0002, $DECLARED= 0x0004;  // Deprecated
   public $reflect;
   protected $mirror;
   private $tags= null;

--- a/src/main/php/lang/mirrors/Members.class.php
+++ b/src/main/php/lang/mirrors/Members.class.php
@@ -43,6 +43,21 @@ abstract class Members extends \lang\Object implements \IteratorAggregate {
   public static function with($predicate) { return (new Predicates())->with($predicate); }
 
   /**
+   * Iterates over members.
+   *
+   * @param  util.Filter $filter
+   * @return php.Generator
+   */
+  public abstract function all($filter= null);
+
+  /**
+   * Iterates over all methods
+   *
+   * @return php.Generator
+   */
+  public function getIterator() { return $this->all(); }
+
+  /**
    * Creates a string representation
    *
    * @return string

--- a/src/main/php/lang/mirrors/Members.class.php
+++ b/src/main/php/lang/mirrors/Members.class.php
@@ -1,0 +1,57 @@
+<?php namespace lang\mirrors;
+
+abstract class Members extends \lang\Object implements \IteratorAggregate {
+  protected $mirror;
+
+  /**
+   * Creates a new methods instance
+   *
+   * @param  lang.mirrors.TypeMirror $mirror
+   */
+  public function __construct(TypeMirror $mirror) {
+    $this->mirror= $mirror;
+  }
+
+  /**
+   * Returns class members
+   *
+   * @return lang.mirrors.Predicates
+   */
+  public static function ofClass() { return (new Predicates())->ofClass(); }
+
+  /**
+   * Returns instance members
+   *
+   * @return lang.mirrors.Predicates
+   */
+  public static function ofInstance() { return (new Predicates())->ofInstance(); }
+
+  /**
+   * Returns members with a given annotation
+   *
+   * @param  string $annotation
+   * @return lang.mirrors.Predicates
+   */
+  public static function withAnnotation($annotation) { return (new Predicates())->withAnnotation($annotation); }
+
+  /**
+   * Returns members that match a given predicate
+   *
+   * @param  function(lang.mirrors.Member): bool $predicate
+   * @return lang.mirrors.Predicates
+   */
+  public static function with($predicate) { return (new Predicates())->with($predicate); }
+
+  /**
+   * Creates a string representation
+   *
+   * @return string
+   */
+  public function toString() {
+    $s= nameof($this)."@[\n";
+    foreach ($this as $member) {
+      $s.= '  '.(string)$member."\n";
+    }
+    return $s.']';
+  }
+}

--- a/src/main/php/lang/mirrors/Members.class.php
+++ b/src/main/php/lang/mirrors/Members.class.php
@@ -1,10 +1,13 @@
 <?php namespace lang\mirrors;
 
+/**
+ * Base class for fields and methods
+ */
 abstract class Members extends \lang\Object implements \IteratorAggregate {
   protected $mirror;
 
   /**
-   * Creates a new methods instance
+   * Creates a new members instance
    *
    * @param  lang.mirrors.TypeMirror $mirror
    */
@@ -49,6 +52,14 @@ abstract class Members extends \lang\Object implements \IteratorAggregate {
    * @return php.Generator
    */
   public abstract function all($filter= null);
+
+  /**
+   * Iterates over declared members.
+   *
+   * @param  util.Filter $filter
+   * @return php.Generator
+   */
+  public abstract function declared($filter= null);
 
   /**
    * Iterates over all methods

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -2,17 +2,12 @@
 
 use lang\ElementNotFoundException;
 
-class Methods extends \lang\Object implements \IteratorAggregate {
-  private $mirror;
-
-  /**
-   * Creates a new methods instance
-   *
-   * @param  lang.mirrors.TypeMirror $mirror
-   */
-  public function __construct(TypeMirror $mirror) {
-    $this->mirror= $mirror;
-  }
+/**
+ * A type's methods 
+ *
+ * @test  xp://lang.mirrors.unittest.TypeMirrorMethodsTest
+ */
+class Methods extends Members {
 
   /**
    * Checks whether a given method is provided
@@ -63,6 +58,20 @@ class Methods extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
+   * Iterates over methods and returns those matching a given filter
+   *
+   * @param  util.Filter $filter
+   * @return php.Generator
+   */
+  public function select($filter) {
+    foreach ($this->mirror->reflect->allMethods() as $name => $member) {
+      if (0 === strncmp('__', $name, 2)) continue;
+      $method= new Method($this->mirror, $member);
+      if ($filter->accept($method)) yield $method;
+    }
+  }
+
+  /**
    * Iterates over methods.
    *
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
@@ -78,18 +87,5 @@ class Methods extends \lang\Object implements \IteratorAggregate {
       if (0 === strncmp('__', $name, 2) || $instance === $method['access']->isStatic()) continue;
       yield new Method($this->mirror, $method);
     }
-  }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    $s= nameof($this)."@[\n";
-    foreach ($this as $method) {
-      $s.= '  '.(string)$method."\n";
-    }
-    return $s.']';
   }
 }

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -34,47 +34,37 @@ class Methods extends Members {
   }
 
   /**
-   * Iterates over all methods
-   *
-   * @return php.Generator
-   */
-  public function getIterator() {
-    foreach ($this->mirror->reflect->allMethods() as $name => $method) {
-      if (0 === strncmp($name, '__', 2)) continue;
-      yield new Method($this->mirror, $method);
-    }
-  }
-
-  /**
-   * Iterates over declared methods.
-   *
-   * @return php.Generator
-   */
-  public function declared() {
-    foreach ($this->mirror->reflect->declaredMethods() as $name => $method) {
-      if (0 === strncmp('__', $name, 2)) continue;
-      yield new Method($this->mirror, $method);
-    }
-  }
-
-  /**
-   * Iterates over methods and returns those matching a given filter
+   * Iterates over fields.
    *
    * @param  util.Filter $filter
    * @return php.Generator
    */
-  public function select($filter) {
+  public function all($filter= null) {
     foreach ($this->mirror->reflect->allMethods() as $name => $member) {
       if (0 === strncmp('__', $name, 2)) continue;
       $method= new Method($this->mirror, $member);
-      if ($filter->accept($method)) yield $method;
+      if (null === $filter || $filter->accept($method)) yield $method;
+    }
+  }
+
+  /**
+   * Iterates over declared fields.
+   *
+   * @param  util.Filter $filter
+   * @return php.Generator
+   */
+  public function declared($filter= null) {
+    foreach ($this->mirror->reflect->declaredMethods() as $name => $member) {
+      if (0 === strncmp('__', $name, 2)) continue;
+      $method= new Method($this->mirror, $member);
+      if (null === $filter || $filter->accept($method)) yield $method;
     }
   }
 
   /**
    * Iterates over methods.
    *
-   * @deprecated Use select() instead
+   * @deprecated Use all() or declared() instead
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
    * @return php.Generator
    */

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -74,6 +74,7 @@ class Methods extends Members {
   /**
    * Iterates over methods.
    *
+   * @deprecated Use select() instead
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
    * @return php.Generator
    */

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -34,7 +34,7 @@ class Methods extends Members {
   }
 
   /**
-   * Iterates over fields.
+   * Iterates over methods.
    *
    * @param  util.Filter $filter
    * @return php.Generator
@@ -48,7 +48,7 @@ class Methods extends Members {
   }
 
   /**
-   * Iterates over declared fields.
+   * Iterates over declared methods.
    *
    * @param  util.Filter $filter
    * @return php.Generator

--- a/src/main/php/lang/mirrors/Predicates.class.php
+++ b/src/main/php/lang/mirrors/Predicates.class.php
@@ -1,0 +1,63 @@
+<?php namespace lang\mirrors;
+
+class Predicates extends \lang\Object implements \util\Filter {
+  private $filters= [];
+
+  /**
+   * Returns instance members
+   *
+   * @return self
+   */
+  public function ofInstance() {
+    return $this->with(function($member) {
+      return !$member->modifiers()->isStatic();
+    });
+  }
+
+  /**
+   * Returns class members
+   *
+   * @return self
+   */
+  public function ofClass() {
+    return $this->with(function($member) {
+      return $member->modifiers()->isStatic();
+    });
+  }
+
+  /**
+   * Returns members with a given annotation
+   *
+   * @param  string $annotation
+   * @return self
+   */
+  public function withAnnotation($annotation) {
+    return $this->with(function($member) use($annotation) {
+      return $member->annotations()->provides($annotation);
+    });
+  }
+
+  /**
+   * Returns members that match a given predicate
+   *
+   * @param  function(lang.mirrors.Member): bool $predicate
+   * @return self
+   */
+  public function with($predicate) {
+    $this->filters[]= $predicate;
+    return $this;
+  }
+
+  /**
+   * Returns whether to accept this member
+   *
+   * @param  lang.mirrors.Member $member
+   * @return bool
+   */
+  public function accept($member) {
+    foreach ($this->filters as $filter) {
+      if (!$filter($member)) return false;
+    }
+    return true;
+  }
+}

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -320,6 +320,8 @@ abstract class SourceTest extends \unittest\TestCase {
   public function all_methods() {
     $this->assertEquals(
       [
+        'annotatedClassMethod',
+        'annotatedInstanceMethod',
         'inheritedMethod',
         'privateClassMethod',
         'privateInstanceMethod',
@@ -337,6 +339,8 @@ abstract class SourceTest extends \unittest\TestCase {
   public function declared_methods() {
     $this->assertEquals(
       [
+        'annotatedClassMethod',
+        'annotatedInstanceMethod',
         'privateClassMethod',
         'privateInstanceMethod',
         'protectedClassMethod',

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -234,6 +234,8 @@ abstract class SourceTest extends \unittest\TestCase {
   public function all_fields() {
     $this->assertEquals(
       [
+        'annotatedClassField',
+        'annotatedInstanceField',
         'inheritedField',
         'privateClassField',
         'privateInstanceField',
@@ -251,6 +253,8 @@ abstract class SourceTest extends \unittest\TestCase {
   public function declared_fields() {
     $this->assertEquals(
       [
+        'annotatedClassField',
+        'annotatedInstanceField',
         'privateClassField',
         'privateInstanceField',
         'protectedClassField',

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
@@ -50,6 +50,8 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function all_fields_by_iterating_field_directly() {
     $this->assertEquals(
       [
+        new Field($this->fixture, 'annotatedClassField'),
+        new Field($this->fixture, 'annotatedInstanceField'),
         new Field($this->fixture, 'inheritedField'),
         new Field($this->fixture, 'privateClassField'),
         new Field($this->fixture, 'privateInstanceField'),
@@ -67,6 +69,8 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function all_fields() {
     $this->assertEquals(
       [
+        new Field($this->fixture, 'annotatedClassField'),
+        new Field($this->fixture, 'annotatedInstanceField'),
         new Field($this->fixture, 'inheritedField'),
         new Field($this->fixture, 'privateClassField'),
         new Field($this->fixture, 'privateInstanceField'),
@@ -84,6 +88,8 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function declared_fields() {
     $this->assertEquals(
       [
+        new Field($this->fixture, 'annotatedClassField'),
+        new Field($this->fixture, 'annotatedInstanceField'),
         new Field($this->fixture, 'privateClassField'),
         new Field($this->fixture, 'privateInstanceField'),
         new Field($this->fixture, 'protectedClassField'),
@@ -100,6 +106,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function instance_fields_via_deprecated_of() {
     $this->assertEquals(
       [
+        new Field($this->fixture, 'annotatedInstanceField'),
         new Field($this->fixture, 'inheritedField'),
         new Field($this->fixture, 'privateInstanceField'),
         new Field($this->fixture, 'protectedInstanceField'),
@@ -114,6 +121,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function static_fields_via_deprecated_of() {
     $this->assertEquals(
       [
+        new Field($this->fixture, 'annotatedClassField'),
         new Field($this->fixture, 'privateClassField'),
         new Field($this->fixture, 'protectedClassField'),
         new Field($this->fixture, 'publicClassField')
@@ -126,6 +134,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function instance_fields() {
     $this->assertEquals(
       [
+        new Field($this->fixture, 'annotatedInstanceField'),
         new Field($this->fixture, 'inheritedField'),
         new Field($this->fixture, 'privateInstanceField'),
         new Field($this->fixture, 'protectedInstanceField'),
@@ -140,11 +149,23 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   public function static_fields() {
     $this->assertEquals(
       [
+        new Field($this->fixture, 'annotatedClassField'),
         new Field($this->fixture, 'privateClassField'),
         new Field($this->fixture, 'protectedClassField'),
         new Field($this->fixture, 'publicClassField')
       ],
       $this->sorted($this->fixture->fields()->all(Fields::ofClass()))
+    );
+  }
+
+  #[@test]
+  public function annotated_fields() {
+    $this->assertEquals(
+      [
+        new Field($this->fixture, 'annotatedClassField'),
+        new Field($this->fixture, 'annotatedInstanceField'),
+      ],
+      $this->sorted($this->fixture->fields()->all(Fields::withAnnotation('annotation')))
     );
   }
 

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
@@ -47,7 +47,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function all_fields() {
+  public function all_fields_by_iterating_field_directly() {
     $this->assertEquals(
       [
         new Field($this->fixture, 'inheritedField'),
@@ -60,6 +60,23 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
         new Field($this->fixture, 'traitField')
       ],
       $this->sorted($this->fixture->fields())
+    );
+  }
+
+  #[@test]
+  public function all_fields() {
+    $this->assertEquals(
+      [
+        new Field($this->fixture, 'inheritedField'),
+        new Field($this->fixture, 'privateClassField'),
+        new Field($this->fixture, 'privateInstanceField'),
+        new Field($this->fixture, 'protectedClassField'),
+        new Field($this->fixture, 'protectedInstanceField'),
+        new Field($this->fixture, 'publicClassField'),
+        new Field($this->fixture, 'publicInstanceField'),
+        new Field($this->fixture, 'traitField')
+      ],
+      $this->sorted($this->fixture->fields()->all())
     );
   }
 
@@ -115,7 +132,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
         new Field($this->fixture, 'publicInstanceField'),
         new Field($this->fixture, 'traitField')
       ],
-      $this->sorted($this->fixture->fields()->select(Fields::ofInstance()))
+      $this->sorted($this->fixture->fields()->all(Fields::ofInstance()))
     );
   }
 
@@ -127,7 +144,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
         new Field($this->fixture, 'protectedClassField'),
         new Field($this->fixture, 'publicClassField')
       ],
-      $this->sorted($this->fixture->fields()->select(Fields::ofClass()))
+      $this->sorted($this->fixture->fields()->all(Fields::ofClass()))
     );
   }
 
@@ -136,7 +153,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
     $namedTrait= function($member) { return (bool)strstr($member->name(), 'trait'); };
     $this->assertEquals(
       [new Field($this->fixture, 'traitField')],
-      $this->sorted($this->fixture->fields()->select(Fields::with($namedTrait)))
+      $this->sorted($this->fixture->fields()->all(Fields::with($namedTrait)))
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
@@ -123,7 +123,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function instance_field() {
+  public function instance_fields() {
     $this->assertEquals(
       [
         new Field($this->fixture, 'inheritedField'),

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorFieldsTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\TypeMirror;
 use lang\mirrors\Field;
+use lang\mirrors\Fields;
 use lang\mirrors\Member;
 use lang\ElementNotFoundException;
 use lang\mirrors\unittest\fixture\MemberFixture;
@@ -79,7 +80,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function instance_fields() {
+  public function instance_fields_via_deprecated_of() {
     $this->assertEquals(
       [
         new Field($this->fixture, 'inheritedField'),
@@ -93,7 +94,7 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function static_fields() {
+  public function static_fields_via_deprecated_of() {
     $this->assertEquals(
       [
         new Field($this->fixture, 'privateClassField'),
@@ -101,6 +102,41 @@ class TypeMirrorFieldsTest extends \unittest\TestCase {
         new Field($this->fixture, 'publicClassField')
       ],
       $this->sorted($this->fixture->fields()->of(Member::$STATIC))
+    );
+  }
+
+  #[@test]
+  public function instance_field() {
+    $this->assertEquals(
+      [
+        new Field($this->fixture, 'inheritedField'),
+        new Field($this->fixture, 'privateInstanceField'),
+        new Field($this->fixture, 'protectedInstanceField'),
+        new Field($this->fixture, 'publicInstanceField'),
+        new Field($this->fixture, 'traitField')
+      ],
+      $this->sorted($this->fixture->fields()->select(Fields::ofInstance()))
+    );
+  }
+
+  #[@test]
+  public function static_fields() {
+    $this->assertEquals(
+      [
+        new Field($this->fixture, 'privateClassField'),
+        new Field($this->fixture, 'protectedClassField'),
+        new Field($this->fixture, 'publicClassField')
+      ],
+      $this->sorted($this->fixture->fields()->select(Fields::ofClass()))
+    );
+  }
+
+  #[@test]
+  public function fields_by_predicate() {
+    $namedTrait= function($member) { return (bool)strstr($member->name(), 'trait'); };
+    $this->assertEquals(
+      [new Field($this->fixture, 'traitField')],
+      $this->sorted($this->fixture->fields()->select(Fields::with($namedTrait)))
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
@@ -173,4 +173,13 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
       $this->sorted($this->fixture->methods()->all(Methods::withAnnotation('annotation')))
     );
   }
+
+  #[@test]
+  public function methods_by_predicate() {
+    $namedTrait= function($member) { return (bool)strstr($member->name(), 'trait'); };
+    $this->assertEquals(
+      [new Method($this->fixture, 'traitMethod')],
+      $this->sorted($this->fixture->methods()->all(Methods::with($namedTrait)))
+    );
+  }
 }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\TypeMirror;
 use lang\mirrors\Method;
+use lang\mirrors\Methods;
 use lang\mirrors\Member;
 use lang\ElementNotFoundException;
 use lang\mirrors\unittest\fixture\MemberFixture;
@@ -54,6 +55,8 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   public function all_methods() {
     $this->assertEquals(
       [
+        new Method($this->fixture, 'annotatedClassMethod'),
+        new Method($this->fixture, 'annotatedInstanceMethod'),
         new Method($this->fixture, 'inheritedMethod'),
         new Method($this->fixture, 'privateClassMethod'),
         new Method($this->fixture, 'privateInstanceMethod'),
@@ -71,6 +74,8 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   public function declared_methods() {
     $this->assertEquals(
       [
+        new Method($this->fixture, 'annotatedClassMethod'),
+        new Method($this->fixture, 'annotatedInstanceMethod'),
         new Method($this->fixture, 'privateClassMethod'),
         new Method($this->fixture, 'privateInstanceMethod'),
         new Method($this->fixture, 'protectedClassMethod'),
@@ -84,9 +89,10 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function instance_methods() {
+  public function instance_methods_via_deprecated_of() {
     $this->assertEquals(
       [
+        new Method($this->fixture, 'annotatedInstanceMethod'),
         new Method($this->fixture, 'inheritedMethod'),
         new Method($this->fixture, 'privateInstanceMethod'),
         new Method($this->fixture, 'protectedInstanceMethod'),
@@ -98,14 +104,54 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function static_methods_via_deprecated_of() {
+    $this->assertEquals(
+      [
+        new Method($this->fixture, 'annotatedClassMethod'),
+        new Method($this->fixture, 'privateClassMethod'),
+        new Method($this->fixture, 'protectedClassMethod'),
+        new Method($this->fixture, 'publicClassMethod'),
+      ],
+      $this->sorted($this->fixture->methods()->of(Member::$STATIC))
+    );
+  }
+
+  #[@test]
+  public function instance_methods() {
+    $this->assertEquals(
+      [
+        new Method($this->fixture, 'annotatedInstanceMethod'),
+        new Method($this->fixture, 'inheritedMethod'),
+        new Method($this->fixture, 'privateInstanceMethod'),
+        new Method($this->fixture, 'protectedInstanceMethod'),
+        new Method($this->fixture, 'publicInstanceMethod'),
+        new Method($this->fixture, 'traitMethod')
+      ],
+      $this->sorted($this->fixture->methods()->select(Methods::ofInstance()))
+    );
+  }
+
+  #[@test]
   public function static_methods() {
     $this->assertEquals(
       [
+        new Method($this->fixture, 'annotatedClassMethod'),
         new Method($this->fixture, 'privateClassMethod'),
         new Method($this->fixture, 'protectedClassMethod'),
-        new Method($this->fixture, 'publicClassMethod')
+        new Method($this->fixture, 'publicClassMethod'),
       ],
-      $this->sorted($this->fixture->methods()->of(Member::$STATIC))
+      $this->sorted($this->fixture->methods()->select(Methods::ofClass()))
+    );
+  }
+
+  #[@test]
+  public function annotated_methods() {
+    $this->assertEquals(
+      [
+        new Method($this->fixture, 'annotatedClassMethod'),
+        new Method($this->fixture, 'annotatedInstanceMethod'),
+      ],
+      $this->sorted($this->fixture->methods()->select(Methods::withAnnotation('annotation')))
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorMethodsTest.class.php
@@ -52,7 +52,7 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function all_methods() {
+  public function all_methods_by_iterating_methods_directly() {
     $this->assertEquals(
       [
         new Method($this->fixture, 'annotatedClassMethod'),
@@ -67,6 +67,25 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
         new Method($this->fixture, 'traitMethod')
       ],
       $this->sorted($this->fixture->methods())
+    );
+  }
+
+  #[@test]
+  public function all_methods() {
+    $this->assertEquals(
+      [
+        new Method($this->fixture, 'annotatedClassMethod'),
+        new Method($this->fixture, 'annotatedInstanceMethod'),
+        new Method($this->fixture, 'inheritedMethod'),
+        new Method($this->fixture, 'privateClassMethod'),
+        new Method($this->fixture, 'privateInstanceMethod'),
+        new Method($this->fixture, 'protectedClassMethod'),
+        new Method($this->fixture, 'protectedInstanceMethod'),
+        new Method($this->fixture, 'publicClassMethod'),
+        new Method($this->fixture, 'publicInstanceMethod'),
+        new Method($this->fixture, 'traitMethod')
+      ],
+      $this->sorted($this->fixture->methods()->all())
     );
   }
 
@@ -127,7 +146,7 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
         new Method($this->fixture, 'publicInstanceMethod'),
         new Method($this->fixture, 'traitMethod')
       ],
-      $this->sorted($this->fixture->methods()->select(Methods::ofInstance()))
+      $this->sorted($this->fixture->methods()->all(Methods::ofInstance()))
     );
   }
 
@@ -140,7 +159,7 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
         new Method($this->fixture, 'protectedClassMethod'),
         new Method($this->fixture, 'publicClassMethod'),
       ],
-      $this->sorted($this->fixture->methods()->select(Methods::ofClass()))
+      $this->sorted($this->fixture->methods()->all(Methods::ofClass()))
     );
   }
 
@@ -151,7 +170,7 @@ class TypeMirrorMethodsTest extends \unittest\TestCase {
         new Method($this->fixture, 'annotatedClassMethod'),
         new Method($this->fixture, 'annotatedInstanceMethod'),
       ],
-      $this->sorted($this->fixture->methods()->select(Methods::withAnnotation('annotation')))
+      $this->sorted($this->fixture->methods()->all(Methods::withAnnotation('annotation')))
     );
   }
 }

--- a/src/test/php/lang/mirrors/unittest/fixture/MemberFixture.class.php
+++ b/src/test/php/lang/mirrors/unittest/fixture/MemberFixture.class.php
@@ -11,6 +11,11 @@ class MemberFixture extends AbstractMemberFixture {
   protected static $protectedClassField;
   private static $privateClassField;
 
+  #[@annotation]
+  public $annotatedInstanceField;
+  #[@annotation]
+  public static $annotatedClassField;
+
   public function publicInstanceMethod() { }
   protected function protectedInstanceMethod() { }
   private function privateInstanceMethod() { }

--- a/src/test/php/lang/mirrors/unittest/fixture/MemberFixture.class.php
+++ b/src/test/php/lang/mirrors/unittest/fixture/MemberFixture.class.php
@@ -17,4 +17,9 @@ class MemberFixture extends AbstractMemberFixture {
   public static function publicClassMethod() { }
   protected static function protectedClassMethod() { }
   private static function privateClassMethod() { }
+
+  #[@annotation]
+  public function annotatedInstanceMethod() { }
+  #[@annotation]
+  public static function annotatedClassMethod() { }
 }


### PR DESCRIPTION
Based on https://github.com/xp-forge/mirrors/issues/20#issuecomment-128991196

## Old

```php
foreach ($type->methods() as $method) {
  if ($method->annotations()->provides('test')) yield $method;
}

foreach ($type->methods()->declared() as $method) {
  if ($method->annotations()->provides('test')) yield $method;
}
```

## New

```php
foreach ($type->methods()->all(Methods::annotatedWith('test')) as $method) {
  yield $method;
}

foreach ($type->methods()->declared(Methods::annotatedWith('test')) as $method) {
  yield $method;
}
```

*...and the same for fields*.

## Predicates
These can be invoked on the `Methods` and `Fields` classes:

```php
public static lang.mirrors.Predicates ofClass()
public static lang.mirrors.Predicates ofInstance()
public static lang.mirrors.Predicates withAnnotation(string $annotation)
public static lang.mirrors.Predicates with(function(lang.mirrors.Member): bool $predicate)
```

To filter e.g. instance methods annotated with a given annotation, combine them:

```php
$filter= Methods::ofInstance()->annotatedWith('test');
```

## of() now deprecated

This pull request deprecates the `of()` method. Here's how to rewrite:

```php
// Before
$type->methods()->of(Member::$INSTANCE);
$type->methods()->of(Member::$STATIC | Member::$DECLARED);

// After
$type->methods()->all(Methods::ofInstance());
$type->methods()->declared(Methods::ofClass());
```

*The next major release (2.0.0 at the time of writing) will remove these deprecated methods!*