### PR TITLE
Refactor: Annotations via compiled meta data

### DIFF
--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -417,12 +417,18 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   protected function methodAnnotations($reflect) {
-    $methods= $this
-      ->resolve('\\'.$reflect->getDeclaringClass()->name)
-      ->codeUnit()
-      ->declaration()['method']
-    ;
-    return isset($methods[$reflect->name]) ? $methods[$reflect->name]['annotations'][null] : null;
+    $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
+    $class= $declaredIn->typeName();
+    if (isset(\xp::$meta[$class])) {
+      $annotations= [];
+      foreach (\xp::$meta[$class][1][$reflect->name][DETAIL_ANNOTATIONS] as $name => $value) {
+        $annotations[$name]= null === $value ? null : new Value($value);
+      }
+      return $annotations;
+    } else {
+      $methods= $declaredIn->codeUnit()->declaration()['method'];
+      return isset($methods[$reflect->name]) ? $methods[$reflect->name]['annotations'][null] : null;
+    }
   }
 
   /**

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -70,15 +70,25 @@ class FromReflection extends \lang\Object implements Source {
     }
   }
 
+  /**
+   * Extracts annotations from compiled meta information
+   *
+   * @param  [:var] $compiled
+   * @param  [:lang.mirrors.parse.Value] $annotations
+   */
+  private function annotationsOf($compiled) {
+    $annotations= [];
+    foreach ($compiled as $name => $value) {
+      $annotations[$name]= null === $value ? null : new Value($value);
+    }
+    return $annotations;
+  }
+
   /** @return var */
   public function typeAnnotations() {
     $class= $this->typeName();
     if (isset(\xp::$meta[$class])) {
-      $annotations= [];
-      foreach (\xp::$meta[$class]['class'][DETAIL_ANNOTATIONS] as $name => $value) {
-        $annotations[$name]= null === $value ? null : new Value($value);
-      }
-      return $annotations;
+      return $this->annotationsOf(\xp::$meta[$class]['class'][DETAIL_ANNOTATIONS]);
     } else {
       return $this->codeUnit()->declaration()['annotations'][null];
     }
@@ -241,11 +251,7 @@ class FromReflection extends \lang\Object implements Source {
     $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
     $class= $declaredIn->typeName();
     if (isset(\xp::$meta[$class])) {
-      $annotations= [];
-      foreach (\xp::$meta[$class][0][$reflect->name][DETAIL_ANNOTATIONS] as $name => $value) {
-        $annotations[$name]= null === $value ? null : new Value($value);
-      }
-      return $annotations;
+      return $this->annotationsOf(\xp::$meta[$class][0][$reflect->name][DETAIL_ANNOTATIONS]);
     } else {
       $fields= $declaredIn->codeUnit()->declaration()['field'];
       return isset($fields[$reflect->name]) ? $fields[$reflect->name]['annotations'][null] : null;
@@ -368,11 +374,8 @@ class FromReflection extends \lang\Object implements Source {
     $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
     $class= $declaredIn->typeName();
     if (isset(\xp::$meta[$class])) {
-      $annotations= [];
-      foreach (\xp::$meta[$class][1][$method][DETAIL_TARGET_ANNO][$target] as $name => $value) {
-        $annotations[$name]= null === $value ? null : new Value($value);
-      }
-      return $annotations;
+      $annotations= \xp::$meta[$class][1][$method][DETAIL_TARGET_ANNO];
+      return isset($annotations[$target]) ? $this->annotationsOf($annotations[$target]) : null;
     } else {
       $methods= $declaredIn->codeUnit()->declaration()['method'];
       return isset($methods[$method]['annotations'][$target]) ? $methods[$method]['annotations'][$target] : null;
@@ -426,11 +429,7 @@ class FromReflection extends \lang\Object implements Source {
     $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
     $class= $declaredIn->typeName();
     if (isset(\xp::$meta[$class])) {
-      $annotations= [];
-      foreach (\xp::$meta[$class][1][$reflect->name][DETAIL_ANNOTATIONS] as $name => $value) {
-        $annotations[$name]= null === $value ? null : new Value($value);
-      }
-      return $annotations;
+      return $this->annotationsOf(\xp::$meta[$class][1][$reflect->name][DETAIL_ANNOTATIONS]);
     } else {
       $methods= $declaredIn->codeUnit()->declaration()['method'];
       return isset($methods[$reflect->name]) ? $methods[$reflect->name]['annotations'][null] : null;

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -238,12 +238,18 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   protected function fieldAnnotations($reflect) {
-    $fields= $this
-      ->resolve('\\'.$reflect->getDeclaringClass()->name)
-      ->codeUnit()
-      ->declaration()['field']
-    ;
-    return isset($fields[$reflect->name]) ? $fields[$reflect->name]['annotations'][null] : null;
+    $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
+    $class= $declaredIn->typeName();
+    if (isset(\xp::$meta[$class])) {
+      $annotations= [];
+      foreach (\xp::$meta[$class][0][$reflect->name][DETAIL_ANNOTATIONS] as $name => $value) {
+        $annotations[$name]= null === $value ? null : new Value($value);
+      }
+      return $annotations;
+    } else {
+      $fields= $declaredIn->codeUnit()->declaration()['field'];
+      return isset($fields[$reflect->name]) ? $fields[$reflect->name]['annotations'][null] : null;
+    }
   }
 
   /**

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -363,14 +363,20 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   protected function paramAnnotations($reflect) {
-    $methods= $this
-      ->resolve('\\'.$reflect->getDeclaringClass()->name)
-      ->codeUnit()
-      ->declaration()['method']
-    ;
     $method= $reflect->getDeclaringFunction()->name;
     $target= '$'.$reflect->name;
-    return isset($methods[$method]['annotations'][$target]) ? $methods[$method]['annotations'][$target] : null;
+    $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
+    $class= $declaredIn->typeName();
+    if (isset(\xp::$meta[$class])) {
+      $annotations= [];
+      foreach (\xp::$meta[$class][1][$method][DETAIL_TARGET_ANNO][$target] as $name => $value) {
+        $annotations[$name]= null === $value ? null : new Value($value);
+      }
+      return $annotations;
+    } else {
+      $methods= $declaredIn->codeUnit()->declaration()['method'];
+      return isset($methods[$method]['annotations'][$target]) ? $methods[$method]['annotations'][$target] : null;
+    }
   }
 
   /**

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\parse\ClassSyntax;
 use lang\mirrors\parse\ClassSource;
+use lang\mirrors\parse\Value;
 use lang\XPClass;
 use lang\Type;
 use lang\Enum;
@@ -70,7 +71,18 @@ class FromReflection extends \lang\Object implements Source {
   }
 
   /** @return var */
-  public function typeAnnotations() { return $this->codeUnit()->declaration()['annotations'][null]; }
+  public function typeAnnotations() {
+    $class= $this->typeName();
+    if (isset(\xp::$meta[$class])) {
+      $annotations= [];
+      foreach (\xp::$meta[$class]['class'][DETAIL_ANNOTATIONS] as $name => $value) {
+        $annotations[$name]= null === $value ? null : new Value($value);
+      }
+      return $annotations;
+    } else {
+      return $this->codeUnit()->declaration()['annotations'][null];
+    }
+  }
 
   /** @return lang.mirrors.Modifiers */
   public function typeModifiers() {

--- a/src/test/php/lang/mirrors/unittest/MethodParametersTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/MethodParametersTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\mirrors\unittest;
 
 use lang\mirrors\Parameter;
+use lang\mirrors\Annotation;
 use lang\mirrors\TypeMirror;
 use lang\Type;
 use lang\Object;
@@ -36,6 +37,9 @@ class MethodParametersTest extends AbstractMethodTest {
    * @return void
    */
   private function longFormParameterFixture($fixture, $other) { }
+
+  #[@$fixture: annotation]
+  private function annotatedParameterFixture($fixture) { }
 
   #[@test, @values([
   #  ['noParameterFixture', false],
@@ -118,6 +122,14 @@ class MethodParametersTest extends AbstractMethodTest {
     $this->assertEquals(
       Type::forName('lang.mirrors.Parameter'),
       $this->fixture('resolvedParameterFixture')->parameters()->named('fixture')->type()
+    );
+  }
+
+  #[@test]
+  public function annotations() {
+    $this->assertEquals(
+      [new Annotation($this->type, 'annotation', null)],
+      iterator_to_array($this->fixture('annotatedParameterFixture')->parameters()->first()->annotations())
     );
   }
 }


### PR DESCRIPTION
This pull request reads annotations via `$xp::meta` if available instead of parsing them from the types' sourcecode. This is a huge performance improvement for code previously handled with core reflection or loaded via XP compiler.