### PR TITLE
Additional shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ public class lang.mirrors.TypeMirror extends lang.Object {
   public lang.mirrors.Interfaces interfaces()
   public lang.mirrors.Constructor constructor()
   public lang.mirrors.Methods methods()
+  public lang.mirrors.Method method(string $named) throws lang.ElementNotFoundException
   public lang.mirrors.Fields fields()
+  public lang.mirrors.Field field(string $named) throws lang.ElementNotFoundException
   public lang.mirrors.Constants constants()
   public lang.mirrors.Annotations annotations()
+  public lang.mirrors.Annotation annotation(string $named) throws lang.ElementNotFoundException
   public self resolve(string $name)
 }
 ```
@@ -63,8 +66,10 @@ public class lang.mirrors.Constructor extends lang.mirrors.Routine {
   public lang.Generic newInstance([var... $args= null]) throws ...
   public lang.mirrors.Throws throws()
   public lang.mirrors.Parameters parameters()
+  public lang.mirrors.Parameter parameter(string|int $arg) throws lang.ElementNotFoundException
   public lang.mirrors.TypeMirror declaredIn()
   public lang.mirrors.Annotations annotations()
+  public lang.mirrors.Annotation annotation(string $named) throws lang.ElementNotFoundException
 }
 ```
 
@@ -98,8 +103,10 @@ public class lang.mirrors.Method extends lang.mirrors.Routine {
   public var invoke([lang.Generic $instance= null], [var[] $args= [ ]]) throws ...
   public lang.mirrors.Throws throws()
   public lang.mirrors.Parameters parameters()
+  public lang.mirrors.Parameter parameter(string|int $arg) throws lang.ElementNotFoundException
   public lang.mirrors.TypeMirror declaredIn()
   public lang.mirrors.Annotations annotations()
+  public lang.mirrors.Annotation annotation(string $named) throws lang.ElementNotFoundException
 }
 
 public class lang.mirrors.Parameters extends lang.Object implements php.IteratorAggregate {
@@ -159,6 +166,7 @@ public class lang.mirrors.Field extends lang.mirrors.Member {
   public void modify(lang.Generic $instance, var $value) throws lang.IllegalArgumentException
   public lang.mirrors.TypeMirror declaredIn()
   public lang.mirrors.Annotations annotations()
+  public lang.mirrors.Annotation annotation(string $named) throws lang.ElementNotFoundException
 }
 ```
 

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -82,6 +82,15 @@ abstract class Member extends \lang\Object {
   }
 
   /**
+   * Returns a annotation by a given name
+   *
+   * @param  string $name
+   * @return lang.mirrors.Annotation
+   * @throws lang.ElementNotFoundException
+   */
+  public function annotation($named) { return $this->annotations()->named($named); }
+
+  /**
    * Returns whether a given value is equal to this member
    *
    * @param  var $cmp

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -88,6 +88,19 @@ class Parameter extends \lang\Object {
   }
 
   /**
+   * Returns whether a given value is equal to this parameter
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && (
+      $this->mirror->equals($cmp->mirror) &&
+      $this->reflect['pos'] === $cmp->reflect['pos']
+    );
+  }
+
+  /**
    * Creates a string representation
    *
    * @return string

--- a/src/main/php/lang/mirrors/Routine.class.php
+++ b/src/main/php/lang/mirrors/Routine.class.php
@@ -25,6 +25,17 @@ abstract class Routine extends Member {
   /** @return lang.mirrors.Parameters */
   public function parameters() { return $this->parameters; }
 
+  /**
+   * Returns a parameter by a given name
+   *
+   * @param  string|int $arg
+   * @return lang.mirrors.Parameter
+   * @throws lang.ElementNotFoundException
+   */
+  public function parameter($arg) {
+    return is_int($arg) ? $this->parameters->at($arg) : $this->parameters->named($arg);
+  }
+
   /** @return lang.mirrors.Throws */
   public function throws() { return new Throws($this); }
 }

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -79,23 +79,50 @@ class TypeMirror extends \lang\Object {
   /** @return lang.mirrors.Kind */
   public function kind() { return $this->reflect->typeKind(); }
 
+  /** @return lang.mirrors.Modifiers */
+  public function modifiers() { return $this->reflect->typeModifiers(); }
+
   /** @return lang.mirrors.Constructor */
   public function constructor() { return new Constructor($this); }
-
-  /** @return lang.mirrors.Methods */
-  public function methods() { return $this->methods; }
-
-  /** @return lang.mirrors.Fields */
-  public function fields() { return $this->fields; }
 
   /** @return lang.mirrors.Constants */
   public function constants() { return new Constants($this); }
 
-  /** @return lang.mirrors.Modifiers */
-  public function modifiers() { return $this->reflect->typeModifiers(); }
+  /** @return lang.mirrors.Methods */
+  public function methods() { return $this->methods; }
+
+  /**
+   * Returns a method by a given name
+   *
+   * @param  string $name
+   * @return lang.mirrors.Method
+   * @throws lang.ElementNotFoundException
+   */
+  public function method($named) { return $this->methods->named($named); }
+
+  /** @return lang.mirrors.Fields */
+  public function fields() { return $this->fields; }
+
+  /**
+   * Returns a field by a given name
+   *
+   * @param  string $name
+   * @return lang.mirrors.Field
+   * @throws lang.ElementNotFoundException
+   */
+  public function field($named) { return $this->fields->named($named); }
 
   /** @return lang.mirrors.Annotations */
   public function annotations() { return new Annotations($this, (array)$this->reflect->typeAnnotations()); }
+
+  /**
+   * Returns a annotation by a given name
+   *
+   * @param  string $name
+   * @return lang.mirrors.Annotation
+   * @throws lang.ElementNotFoundException
+   */
+  public function annotation($named) { return $this->annotations()->named($named); }
 
   /**
    * Resolves a type name in the context of this mirror

--- a/src/test/php/lang/mirrors/unittest/ShortcutsTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ShortcutsTest.class.php
@@ -1,0 +1,62 @@
+<?php namespace lang\mirrors\unittest;
+
+use lang\mirrors\TypeMirror;
+
+#[@fixture]
+class ShortcutsTest extends \unittest\TestCase {
+  use TypeDefinition;
+
+  #[@test]
+  public function method_by_name() {
+    $mirror= $this->mirror('{ public function fixture() { } }');
+    $this->assertEquals($mirror->methods()->named('fixture'), $mirror->method('fixture'));
+  }
+
+  #[@test]
+  public function field_by_name() {
+    $mirror= $this->mirror('{ public $fixture; }');
+    $this->assertEquals($mirror->fields()->named('fixture'), $mirror->field('fixture'));
+  }
+
+  #[@test]
+  public function type_annotation_by_name() {
+    $mirror= new TypeMirror(typeof($this));
+    $this->assertEquals($mirror->annotations()->named('fixture'), $mirror->annotation('fixture'));
+  }
+
+  #[@test]
+  public function method_parameter_by_name() {
+    $mirror= $this->mirror('{ public function fixture($test) { } }');
+    $this->assertEquals(
+      $mirror->methods()->named('fixture')->parameters()->named('test'),
+      $mirror->method('fixture')->parameter('test')
+    );
+  }
+
+  #[@test]
+  public function method_parameter_by_position() {
+    $mirror= $this->mirror('{ public function fixture($test) { } }');
+    $this->assertEquals(
+      $mirror->methods()->named('fixture')->parameters()->at(0),
+      $mirror->method('fixture')->parameter(0)
+    );
+  }
+
+  #[@test]
+  public function method_annotation_by_name() {
+    $mirror= $this->mirror("{ #[@test]\npublic function fixture() { } }");
+    $this->assertEquals(
+      $mirror->methods()->named('fixture')->annotations()->named('test'),
+      $mirror->method('fixture')->annotation('test')
+    );
+  }
+
+  #[@test]
+  public function field_annotation_by_name() {
+    $mirror= $this->mirror("{ #[@test]\npublic \$fixture; }");
+    $this->assertEquals(
+      $mirror->fields()->named('fixture')->annotations()->named('test'),
+      $mirror->field('fixture')->annotation('test')
+    );
+  }
+}


### PR DESCRIPTION
### Current

```php
$mirror->annotations()->named('test');
$mirror->methods()->named('test');
$mirror->fields()->named('test');

$mirror->methods()->named('test')->parameters()->named('test');
$mirror->methods()->named('test')->parameters()->at(0);
$mirror->methods()->named('test')->annotations()->named('test');

// Same three for $mirror->constructor()

$mirror->fields()->named('test')->annotations()->named('test');
```

### Additional shortcuts

```php
$mirror->annotation('test');
$mirror->method('test');
$mirror->field('test');

$mirror->method('test')->parameter('test');
$mirror->method('test')->parameter(0);
$mirror->method('test')->annotation('test');

// Same three for $mirror->constructor()

$mirror->field('test')->annotation('test');
```

* [x] Tests
* [x] Implementation
* [x] Documentation

*Note this PR does not refactor stuff to use short versions by default, this can be done after the merge, it would clutter the attached diff!*