### PR TITLE
Add performance testing: Class parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ before_script:
 
 script:
   - ./unittest src/test/php
+  - ./xp util.profiling.Measure lang.mirrors.performance.ClassParsingPerformance -n 100

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=5.5.0"
   },
   "require-dev" : {
-    "xp-forge/measure" : "^0.1"
+    "xp-forge/measure" : "^0.4"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "xp-forge/parse": "^0.2",
     "php" : ">=5.5.0"
   },
+  "require-dev" : {
+    "xp-forge/measure" : "^0.1"
+  },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]
   }

--- a/src/test/php/lang/mirrors/performance/ClassParsingPerformance.class.php
+++ b/src/test/php/lang/mirrors/performance/ClassParsingPerformance.class.php
@@ -1,0 +1,30 @@
+<?php namespace lang\mirrors\performance;
+
+use lang\mirrors\parse\ClassSyntax;
+use lang\mirrors\parse\ClassSource;
+use lang\reflect\ClassParser;
+use lang\XPClass;
+
+class ClassParsingPerformance extends \util\profiling\Measurable {
+
+  /** @return var[][] */
+  public static function classes() {
+    return [
+      [XPClass::forName('lang.mirrors.unittest.SourceTest')],
+      [XPClass::forName('lang.mirrors.FromReflection')],
+      [XPClass::forName('lang.mirrors.Sources')]
+    ];
+  }
+
+  #[@measure, @values('classes')]
+  public function codeUnitOf($class) {
+    $unit= (new ClassSyntax())->codeUnitOf($class->getName())->declaration();
+    return isset($unit['name']);
+  }
+
+  #[@measure, @values('classes')]
+  public function parseDetails($class) {
+    $details= XPClass::detailsForClass($class->getName());
+    return isset($details['class']);
+  }
+}

--- a/src/test/php/lang/mirrors/performance/ClassParsingPerformance.class.php
+++ b/src/test/php/lang/mirrors/performance/ClassParsingPerformance.class.php
@@ -2,7 +2,6 @@
 
 use lang\mirrors\parse\ClassSyntax;
 use lang\mirrors\parse\ClassSource;
-use lang\reflect\ClassParser;
 use lang\XPClass;
 
 class ClassParsingPerformance extends \util\profiling\Measurable {


### PR DESCRIPTION
Unfortunately it turns out this library is quite slow - see https://github.com/xp-framework/unittest/pull/5#issuecomment-151322401

First thing to improve this it to measure performance, though.

```sh
$ xp util.profiling.Measure lang.mirrors.performance.ClassParsingPerformance -n 100
codeUnitOf(lang.XPClass<lang.mirrors.unittest.SourceTest>): 100 iteration(s), 0.103 seconds, result= true
codeUnitOf(lang.XPClass<lang.mirrors.FromReflection>): 100 iteration(s), 0.200 seconds, result= true
codeUnitOf(lang.XPClass<lang.mirrors.Sources>): 100 iteration(s), 0.002 seconds, result= true
parseDetails(lang.XPClass<lang.mirrors.unittest.SourceTest>): 100 iteration(s), 0.006 seconds, result= true
parseDetails(lang.XPClass<lang.mirrors.FromReflection>): 100 iteration(s), 0.006 seconds, result= true
parseDetails(lang.XPClass<lang.mirrors.Sources>): 100 iteration(s), 0.000 seconds, result= true
```