### PR TITLE
Fix variadics

### DIFF
--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -325,9 +325,14 @@ class FromCode extends \lang\Object implements Source {
    * @return [:var]
    */
   protected function param($pos, $param, $annotations) {
-    if ($param['default']) {
-      $default= function() use($param) { return $param['default']->resolve($this->mirror); };
+    if ($param['var']) {
+      $var= true;
+      $default= null;
+    } else if ($param['default']) {
+      $var= null;
+      $default= function() use($param) { return $param['default']->resolve($this->mirror); };      
     } else {
+      $var= false;
       $default= null;
     }
 
@@ -336,7 +341,7 @@ class FromCode extends \lang\Object implements Source {
       'name'        => $param['name'],
       'type'        => isset($param['type']) ? $this->type($param['type']) : null,
       'ref'         => $param['ref'],
-      'var'         => $param['var'],
+      'var'         => $var,
       'default'     => $default,
       'annotations' => function() use($annotations) { return $annotations; }
     ];

--- a/src/main/php/lang/mirrors/FromHHVMReflection.class.php
+++ b/src/main/php/lang/mirrors/FromHHVMReflection.class.php
@@ -57,11 +57,14 @@ class FromHHVMReflection extends FromReflection {
       $type= function() use ($hint) { return $this->types->map($hint); };
     }
 
-    if ($var= $reflect->isVariadic()) {
+    if ($reflect->isVariadic()) {
+      $var= true;
       $default= null;
     } else if ($reflect->isOptional()) {
+      $var= null;
       $default= function() use($reflect) { return $reflect->getDefaultValue(); };
     } else {
+      $var= false;
       $default= null;
     }
 

--- a/src/main/php/lang/mirrors/FromPhp7Reflection.class.php
+++ b/src/main/php/lang/mirrors/FromPhp7Reflection.class.php
@@ -42,11 +42,14 @@ class FromPhp7Reflection extends FromReflection {
       $type= null;
     }
 
-    if ($var= $reflect->isVariadic()) {
+    if ($reflect->isVariadic()) {
+      $var= true;
       $default= null;
     } else if ($reflect->isOptional()) {
+      $var= null;
       $default= function() use($reflect) { return $reflect->getDefaultValue(); };
     } else {
+      $var= false;
       $default= null;
     }
 

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -425,11 +425,14 @@ class FromReflection extends \lang\Object implements Source {
       $type= null;
     }
 
-    if ($var= self::$VARIADIC_SUPPORTED && $reflect->isVariadic()) {
+    if (self::$VARIADIC_SUPPORTED && $reflect->isVariadic()) {
+      $var= true;
       $default= null;
     } else if ($reflect->isOptional()) {
+      $var= null;
       $default= function() use($reflect) { return $reflect->getDefaultValue(); };
     } else {
+      $var= false;
       $default= null;
     }
 

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -3,6 +3,7 @@
 use lang\Type;
 use lang\IllegalArgumentException;
 use lang\IllegalStateException;
+use lang\mirrors\parse\VariadicTypeRef;
 
 /**
  * A method or constructor parameter
@@ -45,10 +46,17 @@ class Parameter extends \lang\Object {
   public function declaringRoutine() { return $this->mirror; }
 
   /** @return bool */
-  public function isVariadic() { return $this->reflect['var']; }
+  public function isVariadic() {
+    if (null === $this->reflect['var']) {
+      $params= $this->mirror->tags()['param'];
+      $n= $this->reflect['pos'];
+      return isset($params[$n]) && $params[$n] instanceof VariadicTypeRef;
+    }
+    return $this->reflect['var'];
+  }
 
   /** @return bool */
-  public function isOptional() { return $this->reflect['var'] || isset($this->reflect['default']); }
+  public function isOptional() { return isset($this->reflect['default']) || $this->isVariadic(); }
 
   /** @return bool */
   public function isVerified() { return isset($this->reflect['type']); }

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -48,7 +48,7 @@ class Parameter extends \lang\Object {
   public function isVariadic() { return $this->reflect['var']; }
 
   /** @return bool */
-  public function isOptional() { return isset($this->reflect['default']); }
+  public function isOptional() { return $this->reflect['var'] || isset($this->reflect['default']); }
 
   /** @return bool */
   public function isVerified() { return isset($this->reflect['type']); }

--- a/src/main/php/lang/mirrors/parse/PhpSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/PhpSyntax.class.php
@@ -207,8 +207,8 @@ class PhpSyntax extends \text\parse\Syntax {
           'ref'         => isset($values[4]),
           'var'         => isset($values[3]),
           'this'        => $values[1],
-          'default'     => $values[6]];
-        }
+          'default'     => $values[6]
+        ]; }
       ),
       'aliases' => new Match([';' => null, '{' => new Block(true)]), 
       'method' => new Match([';' => null, '{' => new Block(true)]),

--- a/src/main/php/lang/mirrors/parse/TagsSource.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSource.class.php
@@ -21,6 +21,7 @@ class TagsSource extends \text\parse\Tokens {
   const T_CALLABLE = 277;
   const T_ARRAY    = 278;
   const T_THIS     = 279;
+  const T_VARIADIC = 280;
 
   private static $keywords= [
     '@param'    => self::T_PARSED,
@@ -49,7 +50,10 @@ class TagsSource extends \text\parse\Tokens {
     'mixed'     => self::T_VAR,
     'false'     => self::T_BOOL,
     'true'      => self::T_BOOL,
-    'null'      => self::T_VOID
+    'null'      => self::T_VOID,
+
+    '...'       => self::T_VARIADIC,
+    '*'         => self::T_VARIADIC
   ];
 
   /**
@@ -58,7 +62,7 @@ class TagsSource extends \text\parse\Tokens {
    * @param  string $input
    */
   public function __construct($input) {
-    $this->tokens= new StringTokenizer($input, "@\$:()<>[]|, \t\n", true);
+    $this->tokens= new StringTokenizer($input, "@\$:()<>[]|*, \t\n", true);
   }
 
   /** @return var */
@@ -69,6 +73,9 @@ class TagsSource extends \text\parse\Tokens {
         continue;
       } else if ('@' === $token || '$' === $token) {
         $token.= $this->tokens->nextToken();
+      } else if (0 === substr_compare($token, '...', -3)) {
+        $token= substr($token, 0, -3);
+        $this->tokens->pushBack('*');
       }
 
       if (1 === strlen($token)) {

--- a/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
@@ -85,12 +85,12 @@ class TagsSyntax extends \text\parse\Syntax {
             )
           ]),
           new Repeated(new Sequence([new Token('['), new Token(']')], function() { return true; })),
+          new Optional(new Sequence([new Token('*')], function() { return true; }))
         ],
         function($values) {
           $return= $values[0];
-          foreach ($values[1] as $do) {
-            $return= new ArrayTypeRef($return);
-          }
+          foreach ($values[1] as $do) { $return= new ArrayTypeRef($return); }
+          if (isset($values[2])) { $return= new VariadicTypeRef($return); }
           return $return;
         }
       )

--- a/src/main/php/lang/mirrors/parse/VariadicTypeRef.class.php
+++ b/src/main/php/lang/mirrors/parse/VariadicTypeRef.class.php
@@ -1,0 +1,35 @@
+<?php namespace lang\mirrors\parse;
+
+/**
+ * Variadic type reference
+ */
+class VariadicTypeRef extends Resolveable {
+  private $component;
+
+  public function __construct($component) {
+    $this->component= $component;
+  }
+
+  /**
+   * Resolve this value 
+   *
+   * @param  lang.mirrors.Source $source
+   * @return var
+   */
+  public function resolve($type) {
+    return $this->component->resolve($type);
+  }
+
+  /**
+   * Returns whether a given value is equal to this code unit
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->component->equals($cmp->component);
+  }
+
+  /** @return string */
+  public function __toString() { return (string)$this->component; }
+}

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -75,7 +75,7 @@ class ParameterTest extends \unittest\TestCase {
     $this->assertEquals($result, (new Parameter($this->method(null, $signature), 0))->isVariadic());
   }
 
-  #[@test, @ignore, @action(new RuntimeVersion('>=7.0'))]
+  #[@test, @action(new RuntimeVersion('>=7.0'))]
   public function variadic_via_syntax_with_type() {
     $param= new Parameter($this->method(null, '(string... $args)'), 0);
     $this->assertEquals(
@@ -84,7 +84,7 @@ class ParameterTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @ignore, @action(new RuntimeVersion('>=5.6'))]
+  #[@test, @action(new RuntimeVersion('>=5.6'))]
   public function variadic_via_syntax() {
     $param= new Parameter($this->method(null, '(... $args)'), 0);
     $this->assertEquals(

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -10,7 +10,7 @@ use lang\Type;
 use lang\XPClass;
 use lang\Primitive;
 use lang\ClassLoader;
-use lang\mirrors\unittest\fixture\FixtureParams;
+use lang\mirrors\unittest\fixture\Identity;
 
 class ParameterTest extends \unittest\TestCase {
   use TypeDefinition;
@@ -131,9 +131,12 @@ class ParameterTest extends \unittest\TestCase {
     $this->assertEquals(null, (new Parameter($this->method(null, '($arg= null)'), 0))->defaultValue());
   }
 
-  #[@test]
-  public function constant_default_value_for_optional() {
-    $this->assertEquals(FixtureParams::CONSTANT, (new Parameter($this->method(null, '($arg= \lang\mirrors\unittest\fixture\FixtureParams::CONSTANT)'), 0))->defaultValue());
+  #[@test, @values([
+  #  '($arg= \lang\mirrors\unittest\fixture\Identity::NAME)',
+  #  '($arg= Identity::NAME)'
+  #])]
+  public function constant_default_value_for_optional($signature) {
+    $this->assertEquals(Identity::NAME, (new Parameter($this->method(null, $signature), 0))->defaultValue());
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -13,155 +13,181 @@ use lang\ClassLoader;
 use lang\mirrors\unittest\fixture\FixtureParams;
 
 class ParameterTest extends \unittest\TestCase {
-  private static $type= null;
+  private static $fixtures= [];
 
   /**
-   * Creates a new parameter
+   * Creates a new anonymous type
    *
-   * @param  string $method Reference to one of the above fixture methods
-   * @return lang.mirrors.Parameter
+   * @param  string $declaration
+   * @return lang.mirrors.TypeMirror
    */
-  private function newFixture($method, $num) {
-    if (null === self::$type) {
-      self::$type= new TypeMirror(FixtureParams::class);
+  private function type($declaration) {
+    if (!isset(self::$fixtures[$declaration])) {
+      $definition= [
+        'modifiers'  => '',
+        'kind'       => 'class',
+        'extends'    => [],
+        'implements' => [],
+        'use'        => [],
+        'imports'    => []
+      ];
+      self::$fixtures[$declaration]= new TypeMirror(ClassLoader::defineType(
+        self::class.sizeof(self::$fixtures),
+        $definition,
+        $declaration
+      ));
     }
+    return self::$fixtures[$declaration];
+  }
 
-    return new Parameter(new Method(self::$type, $method), $num);
+  /**
+   * Creates a fixture method
+   *
+   * @param  string $comment
+   * @param  string $signature
+   * @return lang.mirrors.Method
+   */
+  private function method($comment, $signature) {
+    return new Method(
+      $this->type('{'.$comment."\npublic function fixture".$signature.' { } }'),
+      'fixture'
+    );
   }
 
   #[@test]
   public function can_create_from_method_and_offset() {
-    new Parameter(new Method(new TypeMirror(FixtureParams::class), 'oneParam'), 0);
+    new Parameter($this->method(null, '($arg)'), 0);
   }
 
   #[@test]
   public function can_create_from_method_and_parameter() {
-    new Parameter(
-      new Method(new TypeMirror(FixtureParams::class), 'oneParam'),
-      new \ReflectionParameter([FixtureParams::class, 'oneParam'], 0)
-    );
+    $method= $this->method(null, '($arg)');
+    new Parameter($method, new \ReflectionParameter([literal($method->declaredIn()->name()), 'fixture'], 0));
   }
 
   #[@test, @expect(IllegalArgumentException::class), @values([
-  #  ['noParam', 0], ['noParam', 1], ['noParam', -1],
-  #  ['oneParam', 1], ['oneParam', -1]
+  #  ['()', 0], ['()', 1], ['()', -1],
+  #  ['($arg)', 1], ['($arg)', -1]
   #])]
-  public function raises_exception_when_parameter_does_not_exist($method, $offset) {
-    $this->newFixture($method, $offset);
+  public function raises_exception_when_parameter_does_not_exist($signature, $offset) {
+    new Parameter($this->method(null, $signature), $offset);
   }
 
   #[@test]
   public function name() {
-    $this->assertEquals('arg', $this->newFixture('oneParam', 0)->name());
+    $this->assertEquals('arg', (new Parameter($this->method(null, '($arg)'), 0))->name());
   }
 
   #[@test]
   public function position() {
-    $this->assertEquals(0, $this->newFixture('oneParam', 0)->position());
+    $this->assertEquals(0, (new Parameter($this->method(null, '($arg)'), 0))->position());
   }
 
   #[@test]
   public function declaringRoutine() {
-    $this->assertEquals(
-      new Method(self::$type, 'oneParam'),
-      $this->newFixture('oneParam', 0)->declaringRoutine()
-    );
+    $method= $this->method(null, '($arg)');
+    $this->assertEquals($method, (new Parameter($method, 0))->declaringRoutine());
   }
 
-  #[@test, @values([['oneOptionalParam', true], ['oneParam', false]])]
-  public function isOptional($method, $result) {
-    $this->assertEquals($result, $this->newFixture($method, 0)->isOptional());
+  #[@test, @values([['($arg= null)', true], ['($arg)', false]])]
+  public function isOptional($signature, $result) {
+    $this->assertEquals($result, (new Parameter($this->method(null, $signature), 0))->isOptional());
   }
 
-  #[@test, @values([['oneParam', false]])]
-  public function isVariadic($method, $result) {
-    $this->assertEquals($result, $this->newFixture($method, 0)->isVariadic());
+  #[@test, @values([['($arg)', false]])]
+  public function isVariadic($signature, $result) {
+    $this->assertEquals($result, (new Parameter($this->method(null, $signature), 0))->isVariadic());
   }
 
   #[@test]
   public function var_is_default_for_no_type_hint() {
-    $this->assertEquals(Type::$VAR, $this->newFixture('oneParam', 0)->type());
+    $this->assertEquals(Type::$VAR, (new Parameter($this->method(null, '($arg)'), 0))->type());
   }
 
   #[@test]
   public function type_hint() {
-    $this->assertEquals(new XPClass(Type::class), $this->newFixture('oneTypeHintedParam', 0)->type());
+    $this->assertEquals(new XPClass(Type::class), (new Parameter($this->method(null, '(\lang\Type $arg)'), 0))->type());
   }
 
   #[@test]
   public function self_type_hint() {
-    $this->assertEquals(new XPClass(FixtureParams::class), $this->newFixture('oneSelfTypeHintedParam', 0)->type());
+    $method= $this->method(null, '(self $arg)');
+    $this->assertEquals(new XPClass($method->declaredIn()->name()), (new Parameter($method, 0))->type());
   }
 
   #[@test]
   public function array_type_hint() {
-    $this->assertEquals(Type::$ARRAY, $this->newFixture('oneArrayTypeHintedParam', 0)->type());
+    $this->assertEquals(Type::$ARRAY, (new Parameter($this->method(null, '(array $arg)'), 0))->type());
   }
 
   #[@test]
   public function callable_type_hint() {
-    $this->assertEquals(Type::$CALLABLE, $this->newFixture('oneCallableTypeHintedParam', 0)->type());
+    $this->assertEquals(Type::$CALLABLE, (new Parameter($this->method(null, '(callable $arg)'), 0))->type());
   }
 
-  #[@test]
-  public function documented_type_hint_using_short_form() {
-    $this->assertEquals(new XPClass(Type::class), $this->newFixture('oneDocumentedTypeParam', 0)->type());
+  #[@test, @values(['/** @param lang.Type */', '/** @param \lang\Type */'])]
+  public function documented_type_hint_using_short_form($comment) {
+    $this->assertEquals(new XPClass(Type::class), (new Parameter($this->method($comment, '($arg)'), 0))->type());
   }
 
-  #[@test, @values(['twoDocumentedTypeParamsWithNames', 'twoDocumentedTypeParamsWithoutNames'])]
-  public function first_parameter_in_documented_type_hint_using_long_form($variation) {
-    $this->assertEquals(new XPClass(Type::class), $this->newFixture($variation, 0)->type());
-  }
-
-  #[@test, @values(['twoDocumentedTypeParamsWithNames', 'twoDocumentedTypeParamsWithoutNames'])]
-  public function second_parameter_in_documented_type_hint_using_long_form($variation) {
-    $this->assertEquals(Primitive::$STRING, $this->newFixture($variation, 1)->type());
-  }
-
-  #[@test, @expect(IllegalStateException::class), @values([
-  #  ['oneParam', 0]
+  #[@test, @values([
+  #  "/**\n * @param lang.Type\n * @param string\n */",
+  #  "/**\n * @param lang.Type \$one\n * @param string \$two\n */"
   #])]
-  public function cannot_get_default_value_for_non_optional($method, $offset) {
-    $this->newFixture($method, $offset)->defaultValue();
+  public function first_parameter_in_documented_type_hint_using_long_form($comment) {
+    $this->assertEquals(new XPClass(Type::class), (new Parameter($this->method($comment, '($one, $two)'), 0))->type());
+  }
+
+  #[@test, @values([
+  #  "/**\n * @param lang.Type\n * @param string\n */",
+  #  "/**\n * @param lang.Type \$one\n * @param string \$two\n */"
+  #])]
+  public function second_parameter_in_documented_type_hint_using_long_form($comment) {
+    $this->assertEquals(Primitive::$STRING, (new Parameter($this->method($comment, '($one, $two)'), 1))->type());
+  }
+
+  #[@test, @expect(IllegalStateException::class)]
+  public function cannot_get_default_value_for_non_optional() {
+    (new Parameter($this->method(null, '($arg)'), 0))->defaultValue();
   }
 
   #[@test]
   public function null_default_value_for_optional() {
-    $this->assertEquals(null, $this->newFixture('oneOptionalParam', 0)->defaultValue());
+    $this->assertEquals(null, (new Parameter($this->method(null, '($arg= null)'), 0))->defaultValue());
   }
 
   #[@test]
   public function constant_default_value_for_optional() {
-    $this->assertEquals(FixtureParams::CONSTANT, $this->newFixture('oneConstantOptionalParam', 0)->defaultValue());
+    $this->assertEquals(FixtureParams::CONSTANT, (new Parameter($this->method(null, '($arg= \lang\mirrors\unittest\fixture\FixtureParams::CONSTANT)'), 0))->defaultValue());
   }
 
   #[@test]
   public function array_default_value_for_optional() {
-    $this->assertEquals([1, 2, 3], $this->newFixture('oneArrayOptionalParam', 0)->defaultValue());
+    $this->assertEquals([1, 2, 3], (new Parameter($this->method(null, '($arg= [1, 2, 3])'), 0))->defaultValue());
   }
 
   #[@test]
   public function no_annotations() {
-    $this->assertFalse($this->newFixture('oneParam', 0)->annotations()->present());
+    $this->assertFalse((new Parameter($this->method(null, '($arg)'), 0))->annotations()->present());
   }
 
   #[@test]
   public function annotated_parameter() {
-    $fixture= $this->newFixture('oneAnnotatedParam', 0);
+    $method= $this->method('#[@$arg: test]', '($arg)');
     $this->assertEquals(
-      [new Annotation(new TypeMirror(self::class), 'test', null)],
-      iterator_to_array($fixture->annotations())
+      [new Annotation($method->declaredIn(), 'test', null)],
+      iterator_to_array((new Parameter($method, 0))->annotations())
     );
   }
 
   #[@test, @values([
-  #  ['oneParam', false],
-  #  ['oneTypeHintedParam', true],
-  #  ['oneSelfTypeHintedParam', true],
-  #  ['oneArrayTypeHintedParam', true],
-  #  ['oneCallableTypeHintedParam', true]
+  #  ['($arg)', false],
+  #  ['(\lang\Type $arg)', true],
+  #  ['(self $arg)', true],
+  #  ['(array $arg)', true],
+  #  ['(callable $arg)', true]
   #])]
-  public function isVerified($method, $expect) {
-    $this->assertEquals($expect, $this->newFixture($method, 0)->isVerified());
+  public function isVerified($signature, $result) {
+    $this->assertEquals($result, (new Parameter($this->method(null, $signature), 0))->isVerified());
   }
 }

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -93,9 +93,9 @@ class ParameterTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @ignore, @values([
-  #  '/** @param var... $args */',
-  #  '/** @param var* $args */'
+  #[@test, @values([
+  #  '/** @param var* $args */',
+  #  '/** @param var... $args */'
   #])]
   public function variadic_via_apidoc($signature) {
     $param= new Parameter($this->method($signature, '($args= null)'), 0);

--- a/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ParameterTest.class.php
@@ -13,32 +13,7 @@ use lang\ClassLoader;
 use lang\mirrors\unittest\fixture\FixtureParams;
 
 class ParameterTest extends \unittest\TestCase {
-  private static $fixtures= [];
-
-  /**
-   * Creates a new anonymous type
-   *
-   * @param  string $declaration
-   * @return lang.mirrors.TypeMirror
-   */
-  private function type($declaration) {
-    if (!isset(self::$fixtures[$declaration])) {
-      $definition= [
-        'modifiers'  => '',
-        'kind'       => 'class',
-        'extends'    => [],
-        'implements' => [],
-        'use'        => [],
-        'imports'    => []
-      ];
-      self::$fixtures[$declaration]= new TypeMirror(ClassLoader::defineType(
-        self::class.sizeof(self::$fixtures),
-        $definition,
-        $declaration
-      ));
-    }
-    return self::$fixtures[$declaration];
-  }
+  use TypeDefinition;
 
   /**
    * Creates a fixture method
@@ -49,7 +24,7 @@ class ParameterTest extends \unittest\TestCase {
    */
   private function method($comment, $signature) {
     return new Method(
-      $this->type('{'.$comment."\npublic function fixture".$signature.' { } }'),
+      $this->mirror('{'.$comment."\npublic function fixture".$signature.' { } }'),
       'fixture'
     );
   }

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -425,7 +425,7 @@ abstract class SourceTest extends \unittest\TestCase {
     $method= $this->reflect(FixtureParams::class)->methodNamed('oneOptionalParam');
     $param= $method['params']()[0];
     $this->assertEquals(
-      [0, 'arg', null, false, false, null],
+      [0, 'arg', null, false, null, null],
       [$param['pos'], $param['name'], $param['type'], $param['ref'], $param['var'], $param['default']()]
     );
   }

--- a/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
@@ -7,7 +7,7 @@ use lang\ClassLoader;
 use lang\Object;
 
 trait TypeDefinition {
-  private static $uniq= 0;
+  private static $fixtures= [];
 
   /** @return lang.mirrors.Source */
   protected function source() { return Sources::$REFLECTION; }
@@ -15,19 +15,26 @@ trait TypeDefinition {
   /**
    * Defines a type
    *
-   * @param  string $body
+   * @param  string $declaration
    * @param  string[] $extends
    * @return lang.XPClass
    */
-  protected function define($body, $extends= [Object::class]) {
-    $declaration= [
-      'kind'       => 'class',
-      'extends'    => $extends,
-      'implements' => [],
-      'use'        => [],
-      'imports'    => [Identity::class => 'Identity']
-    ];
-    return ClassLoader::defineType(nameof($this).self::$uniq++, $declaration, $body);
+  protected function define($declaration, $extends= [Object::class]) {
+    if (!isset(self::$fixtures[$declaration])) {
+      $definition= [
+        'kind'       => 'class',
+        'extends'    => $extends,
+        'implements' => [],
+        'use'        => [],
+        'imports'    => [Identity::class => 'Identity']
+      ];
+      self::$fixtures[$declaration]= ClassLoader::defineType(
+        self::class.sizeof(self::$fixtures),
+        $definition,
+        $declaration
+      );
+    }
+    return self::$fixtures[$declaration];
   }
 
   /**

--- a/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
@@ -29,7 +29,7 @@ trait TypeDefinition {
         'imports'    => [Identity::class => 'Identity']
       ];
       self::$fixtures[$declaration]= ClassLoader::defineType(
-        self::class.sizeof(self::$fixtures),
+        nameof($this).sizeof(self::$fixtures),
         $definition,
         $declaration
       );


### PR DESCRIPTION
Started out as a refactoring but includes a fix for variadic handling:

* [x] Via PHP 5.6 syntax *(also supported in HHVM)*
* [x] Via PHP 7 syntax
* [x] Declared via `var...` in api documentation
* [x] Declared via `var*` in api documentation

Now consistent with xp-framework/core, plus fixes #31
