### PR TITLE
Implement lang.mirrors.TypeMirror::type()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ public class lang.mirrors.TypeMirror extends lang.Object {
 
   public bool present()
   public string name()
+  public lang.Type type()
   public string comment()
   public self parent()
   public lang.mirrors.Kind kind()

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -58,6 +58,9 @@ class FromCode extends \lang\Object implements Source {
   /** @return string */
   public function typeDeclaration() { return $this->decl['name']; }
 
+  /** @return lang.Type */
+  public function typeInstance() { return new XPClass($this->name); }
+
   /** @return string */
   public function packageName() { return strtr($this->unit->package(), '\\', '.'); }
 

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -55,6 +55,9 @@ class FromReflection extends \lang\Object implements Source {
   /** @return string */
   public function typeDeclaration() { return $this->reflect->getShortName(); }
 
+  /** @return lang.Type */
+  public function typeInstance() { return new XPClass($this->reflect); }
+
   /** @return string */
   public function packageName() { return strtr($this->reflect->getNamespaceName(), '\\', '.'); }
 

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -48,6 +48,9 @@ class TypeMirror extends \lang\Object {
   /** @return string */
   public function declaration() { return $this->reflect->typeDeclaration(); }
 
+  /** @return lang.Type */
+  public function type() { return $this->reflect->typeInstance(); }
+
   /** @return string */
   public function comment() {
     $comment= $this->reflect->typeComment();

--- a/src/main/php/xp/mirrors/EnumInformation.class.php
+++ b/src/main/php/xp/mirrors/EnumInformation.class.php
@@ -2,7 +2,6 @@
 
 use lang\mirrors\TypeMirror;
 use lang\Enum;
-use lang\XPClass;
 
 class EnumInformation extends TypeKindInformation {
 
@@ -24,7 +23,7 @@ class EnumInformation extends TypeKindInformation {
     $out->writeLine(' {');
     $this->displayMembers($this->mirror->constants(), $out, $separator);
 
-    foreach (Enum::valuesOf(XPClass::forName($this->mirror->name())) as $member) {
+    foreach (Enum::valuesOf($this->mirror->type()) as $member) {
       $out->write('  ', $member->name(), '(', $member->ordinal(), ')');
       $mirror= new TypeMirror(typeof($member));
       if ($mirror->isSubtypeOf($this->mirror)) {

--- a/src/test/php/lang/mirrors/unittest/SourceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/SourceTest.class.php
@@ -63,6 +63,11 @@ abstract class SourceTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function typeInstance() {
+    $this->assertEquals(new XPClass(self::class), $this->reflect(self::class)->typeInstance());
+  }
+
+  #[@test]
   public function typeComment() {
     $this->assertEquals(
       "/**\n * Base class for source implementation testing\n */",

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorTest.class.php
@@ -82,6 +82,11 @@ class TypeMirrorTest extends TestCase {
   }
 
   #[@test]
+  public function type() {
+    $this->assertEquals(typeof($this), (new TypeMirror(self::class))->type());
+  }
+
+  #[@test]
   public function comment() {
     $this->assertEquals('Tests TypeMirror', (new TypeMirror(self::class))->comment());
   }


### PR DESCRIPTION
Returns a lang.Type instance representing this mirror

```php
$mirror= new TypeMirror(self::class);
$type= $mirror->type();   // lang.XPClass<self>
```