### PR TITLE
Refactor: Use ClassParser from core instead of PHP syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Mirrors",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^6.3.1",
+    "xp-framework/core": "^6.10.2",
     "xp-framework/tokenize": "^6.6",
     "xp-forge/parse": "^0.2",
     "php" : ">=5.5.0"

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -94,10 +94,11 @@ class FromReflection extends \lang\Object implements Source {
   /** @return var */
   public function typeAnnotations() {
     $class= $this->typeName();
-    if (isset(\xp::$meta[$class])) {
-      return $this->annotationsOf(\xp::$meta[$class]['class'][DETAIL_ANNOTATIONS]);
+    $details= XPClass::detailsForClass($class);
+    if ($details && $details['class'][DETAIL_ANNOTATIONS]) {
+      return $this->annotationsOf($details['class'][DETAIL_ANNOTATIONS]);
     } else {
-      return $this->codeUnit()->declaration()['annotations'][null];
+      return null;
     }
   }
 
@@ -279,14 +280,11 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   protected function fieldAnnotations($reflect) {
-    $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
-    $class= $declaredIn->typeName();
-    if (isset(\xp::$meta[$class])) {
-      return $this->annotationsOf(\xp::$meta[$class][0][$reflect->name][DETAIL_ANNOTATIONS]);
-    } else {
-      $field= $this->memberDeclaration($declaredIn, 'field', $reflect->name);
-      return isset($field['annotations']) ? $field['annotations'][null] : null;
-    }
+    $details= XPClass::detailsForField($reflect->getDeclaringClass(), $reflect->name);
+    return isset($details[DETAIL_ANNOTATIONS])
+      ? $this->annotationsOf($details[DETAIL_ANNOTATIONS])
+      : null
+    ;
   }
 
   /**
@@ -397,17 +395,12 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   protected function paramAnnotations($reflect) {
-    $name= $reflect->getDeclaringFunction()->name;
     $target= '$'.$reflect->name;
-    $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
-    $class= $declaredIn->typeName();
-    if (isset(\xp::$meta[$class])) {
-      $annotations= \xp::$meta[$class][1][$name][DETAIL_TARGET_ANNO];
-      return isset($annotations[$target]) ? $this->annotationsOf($annotations[$target]) : null;
-    } else {
-      $method= $this->memberDeclaration($declaredIn, 'method', $name);
-      return isset($method['annotations'][$target]) ? $method['annotations'][$target] : null;
-    }
+    $details= XPClass::detailsForMethod($reflect->getDeclaringClass(), $reflect->getDeclaringFunction()->name);
+    return isset($details[DETAIL_TARGET_ANNO][$target])
+      ? $this->annotationsOf($details[DETAIL_TARGET_ANNO][$target])
+      : null
+    ;
   }
 
   /**
@@ -457,14 +450,11 @@ class FromReflection extends \lang\Object implements Source {
    * @return [:var]
    */
   protected function methodAnnotations($reflect) {
-    $declaredIn= $this->resolve('\\'.$reflect->getDeclaringClass()->name);
-    $class= $declaredIn->typeName();
-    if (isset(\xp::$meta[$class])) {
-      return $this->annotationsOf(\xp::$meta[$class][1][$reflect->name][DETAIL_ANNOTATIONS]);
-    } else {
-      $method= $this->memberDeclaration($declaredIn, 'method', $reflect->name);
-      return isset($method['annotations']) ? $method['annotations'][null] : null;
-    }
+    $details= XPClass::detailsForMethod($reflect->getDeclaringClass(), $reflect->name);
+    return isset($details[DETAIL_ANNOTATIONS])
+      ? $this->annotationsOf($details[DETAIL_ANNOTATIONS])
+      : null
+    ;
   }
 
   /**

--- a/src/test/php/lang/mirrors/unittest/NoParentTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/NoParentTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\TypeMirror;
 use lang\IllegalStateException;
+use lang\ClassFormatException;
 
 abstract class NoParentTest extends \unittest\TestCase {
   use TypeDefinition;
@@ -26,7 +27,7 @@ abstract class NoParentTest extends \unittest\TestCase {
     ;
   }
 
-  #[@test, @expect(IllegalStateException::class)]
+  #[@test, @expect(ClassFormatException::class)]
   public function annotation_value() {
     $this->mirror("{ #[@fixture(new parent())]\npublic function fixture() { } }", [])
       ->methods()

--- a/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
@@ -26,7 +26,7 @@ trait TypeDefinition {
         'extends'    => $extends,
         'implements' => [],
         'use'        => [],
-        'imports'    => [Identity::class => 'Identity']
+        'imports'    => [Identity::class => null]
       ];
       self::$fixtures[$declaration]= ClassLoader::defineType(
         nameof($this).sizeof(self::$fixtures),


### PR DESCRIPTION
Big performance improvement. Would love to refactor this back to xp-forge/parse again, but it desparately needs to speed up first.

**Before:**
```sh
Timm@slate ~/devel/xp/mirrors [master]
$ xp test src/test/php/
# ...

♥: 889/915 run (26 skipped), 889 succeeded, 0 failed
Memory used: 7619.86 kB (7845.76 kB peak)
Time taken: 0.419 seconds
```

**After:**
```sh
Timm@slate ~/devel/xp/mirrors [refactor/use-classparser]
$ xp test src/test/php/
# ...

♥: 889/915 run (26 skipped), 889 succeeded, 0 failed
Memory used: 6535.17 kB (8201.34 kB peak)
Time taken: 0.343 seconds
```

The speedup is even more visible [in other situations](https://github.com/xp-framework/unittest/pull/18).

https://github.com/xp-forge/parse/pull/1 is in the works but unfortunately not fully supportive of all constellations, and due to its complex implementation probably also will not be ready in any time near.

*Bumps dependency on xp-framework/core from 6.5 to [6.10.2](https://github.com/xp-framework/core/releases/tag/v6.10.2)*