### PR TITLE
Refactor: Lazy initialization for members, caching

### DIFF
--- a/src/main/php/lang/mirrors/InstanceMirror.class.php
+++ b/src/main/php/lang/mirrors/InstanceMirror.class.php
@@ -14,8 +14,6 @@ class InstanceMirror extends TypeMirror {
 
       // Parent constructor inlined
       $this->reflect= Sources::$REFLECTION->reflect(new \ReflectionObject($value));
-      $this->methods= new Methods($this);
-      $this->fields= new Fields($this);
     } else {
       throw new IllegalArgumentException('Given value is not an object, '.typeof($value).' given');
     }

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -11,6 +11,7 @@ abstract class Member extends \lang\Object {
   public $reflect;
   protected $mirror;
   private $tags= null;
+  private $annotations= null;
 
   /**
    * Creates a new member
@@ -77,8 +78,11 @@ abstract class Member extends \lang\Object {
 
   /** @return lang.mirrors.Annotations */
   public function annotations() {
-    $annotations= $this->reflect['annotations']();
-    return new Annotations($this->mirror, (array)$annotations);
+    if (null === $this->annotations) {
+      $annotations= $this->reflect['annotations']();
+      $this->annotations= new Annotations($this->mirror, (array)$annotations);
+    }
+    return $this->annotations;
   }
 
   /**

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -17,8 +17,9 @@ use lang\IllegalArgumentException;
  * @test   xp://lang.mirrors.unittest.TypeMirrorTraitsTest
  */
 class TypeMirror extends \lang\Object {
-  protected $methods= null;
-  protected $fields= null;
+  private $methods= null;
+  private $fields= null;
+  private $annotations= null;
   public $reflect;
 
   /**
@@ -114,7 +115,7 @@ class TypeMirror extends \lang\Object {
   public function field($named) { return $this->fields()->named($named); }
 
   /** @return lang.mirrors.Annotations */
-  public function annotations() { return new Annotations($this, (array)$this->reflect->typeAnnotations()); }
+  public function annotations() { return $this->annotations ?: $this->annotations= new Annotations($this, (array)$this->reflect->typeAnnotations()); }
 
   /**
    * Returns a annotation by a given name

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -17,7 +17,8 @@ use lang\IllegalArgumentException;
  * @test   xp://lang.mirrors.unittest.TypeMirrorTraitsTest
  */
 class TypeMirror extends \lang\Object {
-  protected $methods, $fields;
+  protected $methods= null;
+  protected $fields= null;
   public $reflect;
 
   /**
@@ -34,9 +35,6 @@ class TypeMirror extends \lang\Object {
     } else {
       $this->reflect= $source->reflect($arg);
     }
-
-    $this->methods= new Methods($this);
-    $this->fields= new Fields($this);
   }
 
   /** @return bool */
@@ -92,7 +90,7 @@ class TypeMirror extends \lang\Object {
   public function constants() { return new Constants($this); }
 
   /** @return lang.mirrors.Methods */
-  public function methods() { return $this->methods; }
+  public function methods() { return $this->methods ?: $this->methods= new Methods($this); }
 
   /**
    * Returns a method by a given name
@@ -101,10 +99,10 @@ class TypeMirror extends \lang\Object {
    * @return lang.mirrors.Method
    * @throws lang.ElementNotFoundException
    */
-  public function method($named) { return $this->methods->named($named); }
+  public function method($named) { return $this->methods()->named($named); }
 
   /** @return lang.mirrors.Fields */
-  public function fields() { return $this->fields; }
+  public function fields() { return $this->fields ?: $this->fields= new Fields($this); }
 
   /**
    * Returns a field by a given name
@@ -113,7 +111,7 @@ class TypeMirror extends \lang\Object {
    * @return lang.mirrors.Field
    * @throws lang.ElementNotFoundException
    */
-  public function field($named) { return $this->fields->named($named); }
+  public function field($named) { return $this->fields()->named($named); }
 
   /** @return lang.mirrors.Annotations */
   public function annotations() { return new Annotations($this, (array)$this->reflect->typeAnnotations()); }


### PR DESCRIPTION
**Before:**

```sh
Timm@slate ~/devel/xp/unittest [refactor/use-mirrors]
$ xp test src/test/php/
# ...

♥: 388/399 run (11 skipped), 388 succeeded, 0 failed
Memory used: 7867.74 kB (8337.23 kB peak)
Time taken: 0.527 seconds
```

**After:**

```sh
Timm@slate ~/devel/xp/unittest [refactor/use-mirrors]
$ xp test src/test/php/
# ...

♥: 388/399 run (11 skipped), 388 succeeded, 0 failed
Memory used: 6320.70 kB (8174.78 kB peak)
Time taken: 0.484 seconds
```

*Quite a noticeable impact on memory usage, and a solid improvement in performance*