### PR TITLE
Drop PHP 5.5 support, make use of PHP 5.6 varargs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.3.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.4.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mirrors
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-forge/mirrors.svg)](http://travis-ci.org/xp-forge/mirrors)
 [![XP Framework Module](https://raw.githubusercontent.com/xp-framework/web/master/static/xp-framework-badge.png)](https://github.com/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
-[![Required PHP 5.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_5plus.png)](http://php.net/)
+[![Required PHP 5.6+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_6plus.png)](http://php.net/)
 [![Supports PHP 7.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-7_0plus.png)](http://php.net/)
 [![Supports HHVM 3.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_5plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/mirrors/version.png)](https://packagist.org/packages/xp-forge/mirrors)

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "xp-framework/core": "^7.0 | ^6.5",
     "xp-framework/tokenize": "^7.0 | ^6.6",
     "xp-forge/parse": "^1.0",
-    "php" : ">=5.5.0"
+    "php" : ">=5.6.0"
   },
   "require-dev" : {
     "xp-framework/unittest": "^7.0 | ^6.5",

--- a/src/main/php/lang/mirrors/Constructor.class.php
+++ b/src/main/php/lang/mirrors/Constructor.class.php
@@ -26,7 +26,7 @@ class Constructor extends Routine {
    * @param  var... $args
    * @return lang.Generic
    */
-  public function newInstance() { $args= func_get_args(); return $this->mirror->reflect->newInstance($args); }
+  public function newInstance(... $args) { return $this->mirror->reflect->newInstance($args); }
 
   /** @return string */
   public function __toString() {

--- a/src/main/php/xp/mirrors/Highlighting.class.php
+++ b/src/main/php/xp/mirrors/Highlighting.class.php
@@ -19,6 +19,12 @@ class Highlighting {
     }
   }
 
+  /**
+   * Write
+   *
+   * @param  var[] $args
+   * @return void
+   */
   private function write0($args) {
     $line= '';
     foreach ($args as $arg) {
@@ -30,19 +36,19 @@ class Highlighting {
   /**
    * Write
    *
-   * @param  string... $args
+   * @param  var... $args
    */
-  public function write() {
-    $this->write0(func_get_args());
+  public function write(... $args) {
+    $this->write0($args);
   }
 
   /**
    * Write line
    *
-   * @param  string... $args
+   * @param  var... $args
    */
-  public function writeLine() {
-    $this->write0(func_get_args());
+  public function writeLine(... $args) {
+    $this->write0($args);
     $this->out->write("\n");
   }
 }

--- a/src/test/php/lang/mirrors/unittest/ConstructorTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ConstructorTest.class.php
@@ -56,7 +56,7 @@ class ConstructorTest extends \unittest\TestCase {
   public function creating_instances_invokes_constructor() {
     $fixture= newinstance(Object::class, [], '{
       public $passed= null;
-      public function __construct() { $this->passed= func_get_args(); }
+      public function __construct(... $args) { $this->passed= $args; }
     }');
     $this->assertEquals(
       [1, 2, 3],

--- a/src/test/php/lang/mirrors/unittest/MethodInvocationTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/MethodInvocationTest.class.php
@@ -13,7 +13,7 @@ class MethodInvocationTest extends AbstractMethodTest {
 
   private function returnsTestFixture() { return 'Test'; }
 
-  private function returnsArgsFixture() { return func_get_args(); }
+  private function returnsArgsFixture(... $args) { return $args; }
 
   private function throwsExceptionFixture() { throw new IllegalArgumentException('Test'); }
 

--- a/src/test/php/lang/mirrors/unittest/parse/NewInstanceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/NewInstanceTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\mirrors\unittest\parse;
 
+use lang\Object;
 use lang\mirrors\parse\NewInstance;
 use lang\mirrors\parse\Value;
 
@@ -8,16 +9,16 @@ class NewInstanceTest extends ResolveableTest {
   #[@test]
   public function resolved() {
     $this->assertInstanceOf(
-      'lang.Object',
+      Object::class,
       (new NewInstance('lang.Object', []))->resolve($this->source)
     );
   }
 
   #[@test]
   public function passes_args_to_constructor() {
-    $fixture= newinstance('lang.Object', [], '{
+    $fixture= newinstance(Object::class, [], '{
       public $passed= null;
-      public function __construct() { $this->passed= func_get_args(); }
+      public function __construct(... $args) { $this->passed= $args; }
     }');
     $this->assertEquals(
       ['Test', 1],


### PR DESCRIPTION
## Changes

Migration to use native PHP 5.6 varargs syntax instead of `func_get_args()`.

## ⚠️ BC break

 **This would make the next release version 4.0.0**. While we're at it we might consider merging #34 