### PR TITLE
Implement object type union

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ Mirrors change log
 
 ## ?.?.? / ????-??-??
 
+* Fixed parsing `iterable` type from apidocs - @thekid
+
 ## 4.0.0 / 2016-07-24
 
 * Added preliminary support for iterable types (currently inactive

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Mirrors",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^7.0 | ^6.10.2",
+    "xp-framework/core": "dev-feature/object-type as 7.5",
     "xp-framework/tokenize": "^7.0 | ^6.6",
     "xp-forge/parse": "^1.0",
     "php" : ">=5.6.0"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "xp-framework/unittest": "^7.0 | ^6.5",
     "xp-forge/measure" : "^1.0"
   },
+  "suggest" : {
+    "xp-framework/core": "^7.5"
+  },
   "bin": ["bin/xp.xp-forge.mirrors.mirror"],
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Mirrors",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "dev-feature/object-type as 7.5",
+    "xp-framework/core": "^7.0 | ^6.10.2",
     "xp-framework/tokenize": "^7.0 | ^6.6",
     "xp-forge/parse": "^1.0",
     "php" : ">=5.6.0"

--- a/src/main/php/lang/mirrors/parse/TagsSource.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSource.class.php
@@ -22,6 +22,7 @@ class TagsSource extends \text\parse\Tokens {
   const T_ARRAY    = 278;
   const T_THIS     = 279;
   const T_VARIADIC = 280;
+  const T_ITERABLE = 281;
 
   private static $keywords= [
     '@param'    => self::T_PARSED,
@@ -39,6 +40,7 @@ class TagsSource extends \text\parse\Tokens {
     'void'      => self::T_VOID,
     'callable'  => self::T_CALLABLE,
     'array'     => self::T_ARRAY,
+    'iterable'  => self::T_ITERABLE,
 
     'float'     => self::T_DOUBLE,
     'integer'   => self::T_INT,

--- a/src/main/php/lang/mirrors/parse/TagsSource.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSource.class.php
@@ -23,6 +23,7 @@ class TagsSource extends \text\parse\Tokens {
   const T_THIS     = 279;
   const T_VARIADIC = 280;
   const T_ITERABLE = 281;
+  const T_OBJECT   = 282;
 
   private static $keywords= [
     '@param'    => self::T_PARSED,
@@ -41,6 +42,7 @@ class TagsSource extends \text\parse\Tokens {
     'callable'  => self::T_CALLABLE,
     'array'     => self::T_ARRAY,
     'iterable'  => self::T_ITERABLE,
+    'object'    => self::T_OBJECT,
 
     'float'     => self::T_DOUBLE,
     'integer'   => self::T_INT,
@@ -48,7 +50,6 @@ class TagsSource extends \text\parse\Tokens {
 
     '$this'     => self::T_THIS,
     'resource'  => self::T_VAR,
-    'object'    => self::T_VAR,
     'mixed'     => self::T_VAR,
     'false'     => self::T_BOOL,
     'true'      => self::T_BOOL,

--- a/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
@@ -59,6 +59,7 @@ class TagsSyntax extends \text\parse\Syntax {
             TagsSource::T_VAR      => new Returns(new TypeRef(Type::$VAR)),
             TagsSource::T_VOID     => new Returns(new TypeRef(Type::$VOID)),
             TagsSource::T_CALLABLE => new Returns(new TypeRef(Type::$CALLABLE)),
+            TagsSource::T_ITERABLE => new Returns(new TypeRef(Type::$ITERABLE)),
             TagsSource::T_ARRAY    => new Returns(new TypeRef(Type::$ARRAY)),
             TagsSource::T_THIS     => new Returns(new ReferenceTypeRef('self')),
             TagsSource::T_FUNCTION => new Sequence(

--- a/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
@@ -59,9 +59,9 @@ class TagsSyntax extends \text\parse\Syntax {
             TagsSource::T_VAR      => new Returns(new TypeRef(Type::$VAR)),
             TagsSource::T_VOID     => new Returns(new TypeRef(Type::$VOID)),
             TagsSource::T_CALLABLE => new Returns(new TypeRef(Type::$CALLABLE)),
-            TagsSource::T_ITERABLE => new Returns(new TypeRef(Type::$ITERABLE)),
             TagsSource::T_ARRAY    => new Returns(new TypeRef(Type::$ARRAY)),
-            TagsSource::T_OBJECT   => new Returns(new TypeRef(Type::$OBJECT)),
+            TagsSource::T_ITERABLE => new Returns(new TypeRef(property_exists(Type::class, 'ITERABLE') ? Type::$ITERABLE : Type::$VAR)),
+            TagsSource::T_OBJECT   => new Returns(new TypeRef(property_exists(Type::class, 'OBJECT') ? Type::$OBJECT : Type::$VAR)),
             TagsSource::T_THIS     => new Returns(new ReferenceTypeRef('self')),
             TagsSource::T_FUNCTION => new Sequence(
               [new Token('('), new Repeated(new Apply('types'), new Token(',')), new Token(')'), new Token(':'), new Apply('type')],

--- a/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/TagsSyntax.class.php
@@ -61,6 +61,7 @@ class TagsSyntax extends \text\parse\Syntax {
             TagsSource::T_CALLABLE => new Returns(new TypeRef(Type::$CALLABLE)),
             TagsSource::T_ITERABLE => new Returns(new TypeRef(Type::$ITERABLE)),
             TagsSource::T_ARRAY    => new Returns(new TypeRef(Type::$ARRAY)),
+            TagsSource::T_OBJECT   => new Returns(new TypeRef(Type::$OBJECT)),
             TagsSource::T_THIS     => new Returns(new ReferenceTypeRef('self')),
             TagsSource::T_FUNCTION => new Sequence(
               [new Token('('), new Repeated(new Apply('types'), new Token(',')), new Token(')'), new Token(':'), new Apply('type')],

--- a/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
@@ -4,6 +4,7 @@ use lang\mirrors\TypeMirror;
 use lang\mirrors\Method;
 use lang\Type;
 use lang\Primitive;
+use unittest\actions\VerifyThat;
 
 class MethodReturnTypeTest extends AbstractMethodTest {
 
@@ -61,12 +62,12 @@ class MethodReturnTypeTest extends AbstractMethodTest {
 
   #[@test]
   public function iterable_supported() {
-    $this->assertEquals(Type::$ITERABLE, $this->fixture('iterableFixture')->returns());
+    $this->assertEquals(property_exists(Type::class, 'ITERABLE') ? Type::$ITERABLE : Type::$VAR, $this->fixture('iterableFixture')->returns());
   }
 
   #[@test]
   public function object_supported() {
-    $this->assertEquals(Type::$OBJECT, $this->fixture('objectFixture')->returns());
+    $this->assertEquals(property_exists(Type::class, 'OBJECT') ? Type::$OBJECT : Type::$VAR, $this->fixture('objectFixture')->returns());
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
@@ -28,6 +28,9 @@ class MethodReturnTypeTest extends AbstractMethodTest {
   /** @return iterable */
   private function iterableFixture() { }
 
+  /** @return object */
+  private function objectFixture() { }
+
   /** @return Method */
   private function resolved() { }
 
@@ -59,6 +62,11 @@ class MethodReturnTypeTest extends AbstractMethodTest {
   #[@test]
   public function iterable_supported() {
     $this->assertEquals(Type::$ITERABLE, $this->fixture('iterableFixture')->returns());
+  }
+
+  #[@test]
+  public function object_supported() {
+    $this->assertEquals(Type::$OBJECT, $this->fixture('objectFixture')->returns());
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
@@ -25,6 +25,9 @@ class MethodReturnTypeTest extends AbstractMethodTest {
   /** @return parent */
   private function parentFixture() { }
 
+  /** @return iterable */
+  private function iterableFixture() { }
+
   /** @return Method */
   private function resolved() { }
 
@@ -51,6 +54,11 @@ class MethodReturnTypeTest extends AbstractMethodTest {
   #[@test]
   public function parent_supported() {
     $this->assertEquals($this->getClass()->getParentclass(), $this->fixture('parentFixture')->returns());
+  }
+
+  #[@test]
+  public function iterable_supported() {
+    $this->assertEquals(Type::$ITERABLE, $this->fixture('iterableFixture')->returns());
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
@@ -54,6 +54,22 @@ class TagsSyntaxTest extends \unittest\TestCase {
     $this->assertEquals(['param' => [$type]], $this->parse($declaration));
   }
 
+  #[@test]
+  public function object_type() {
+    $this->assertEquals(
+      ['param' => [new TypeRef(property_exists(Type::class, 'OBJECT') ? Type::$OBJECT : Type::$VAR)]],
+      $this->parse('@param object')
+    );
+  }
+
+  #[@test]
+  public function iterable_type() {
+    $this->assertEquals(
+      ['param' => [new TypeRef(property_exists(Type::class, 'ITERABLE') ? Type::$ITERABLE : Type::$VAR)]],
+      $this->parse('@param iterable')
+    );
+  }
+
   #[@test, @values([
   #  ['@param self', new ReferenceTypeRef('self')],
   #  ['@param parent', new ReferenceTypeRef('parent')],

--- a/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
@@ -199,7 +199,7 @@ class TagsSyntaxTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  ['@param resource', new TypeRef(Type::$VAR)],
-  #  ['@param object', new TypeRef(Type::$VAR)],
+  #  ['@param object', new TypeRef(Type::$OBJECT)],
   #  ['@param mixed', new TypeRef(Type::$VAR)],
   #  ['@param null', new TypeRef(Type::$VOID)],
   #  ['@param false', new TypeRef(Primitive::$BOOL)],

--- a/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/TagsSyntaxTest.class.php
@@ -199,7 +199,6 @@ class TagsSyntaxTest extends \unittest\TestCase {
 
   #[@test, @values([
   #  ['@param resource', new TypeRef(Type::$VAR)],
-  #  ['@param object', new TypeRef(Type::$OBJECT)],
   #  ['@param mixed', new TypeRef(Type::$VAR)],
   #  ['@param null', new TypeRef(Type::$VOID)],
   #  ['@param false', new TypeRef(Primitive::$BOOL)],


### PR DESCRIPTION
This pull request adds support for the "object" type union introduced in https://github.com/xp-framework/core/pull/155.

*Note: When running in conjunction with XP core versions before 7.5.0, both `iterable` and `object` will be yielded as the `var` type*.