### PR TITLE
Implement grouped imports

### DIFF
--- a/src/test/php/lang/mirrors/unittest/parse/PhpSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/PhpSyntaxTest.class.php
@@ -150,10 +150,18 @@ class PhpSyntaxTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function aliase_import() {
+  public function aliased_import() {
     $this->assertEquals(
       ['Aliased' => 'util\Objects'],
       $this->parse('<?php use util\Objects as Aliased; class Test { }')->imports()
+    );
+  }
+
+  #[@test]
+  public function grouped_import() {
+    $this->assertEquals(
+      ['Date' => 'util\Date', 'DateUtil' => 'util\DateUtil'],
+      $this->parse('<?php use util\{Date, DateUtil}; class Test { }')->imports()
     );
   }
 

--- a/src/test/php/lang/mirrors/unittest/parse/PhpSyntaxTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/PhpSyntaxTest.class.php
@@ -158,7 +158,15 @@ class PhpSyntaxTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function grouped_import() {
+  public function useless_but_syntactically_valid_single_grouped_import() {
+    $this->assertEquals(
+      ['Date' => 'util\Date'],
+      $this->parse('<?php use util\{Date}; class Test { }')->imports()
+    );
+  }
+
+  #[@test]
+  public function grouped_imports() {
     $this->assertEquals(
       ['Date' => 'util\Date', 'DateUtil' => 'util\DateUtil'],
       $this->parse('<?php use util\{Date, DateUtil}; class Test { }')->imports()


### PR DESCRIPTION
This pull request fixes issue #40 by adding support for [grouped use statements](https://wiki.php.net/rfc/group_use_declarations).

```php
<?php

use lang\partial\{ToString, HashCode};   // This

class Test {
  use Test\including\ToString;
  use Test\including\HashCode;
}
```