### PR TITLE
XP9 Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 php:
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ php:
 
 matrix:
   allow_failures:
+    - php: hhvm
     - php: nightly
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
 
 script:
   - sh xp-run xp.unittest.TestRunner src/test/php
-  - sh xp-run util.profiling.Measure lang.mirrors.performance.ClassParsingPerformance -n 100
+  - sh xp-run xp.measure.Runner lang.mirrors.performance.ClassParsingPerformance -n 100

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ Mirrors change log
 
 ## ?.?.? / ????-??-??
 
+## 5.0.0 / 2017-06-04
+
+* Added forward compatibility with XP 9.0.0 - @thekid
+
 ## 4.2.3 / 2017-02-07
 
 * Fixed issue #40: PHP7 grouped use statement by merging PR #41

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ public class lang.mirrors.Methods extends lang.Object implements php.IteratorAgg
 
   public bool provides(string $name)
   public lang.mirrors.Method named(string $name) throws lang.ElementNotFoundException
-  public php.Generator all([lang.mirrors.Predicates $filter= null])
-  public php.Generator declared([lang.mirrors.Predicates $filter= null])
-  public php.Generator getIterator()
+  public iterable all([lang.mirrors.Predicates $filter= null])
+  public iterable declared([lang.mirrors.Predicates $filter= null])
+  public iterable getIterator()
 }
 
 public class lang.mirrors.Method extends lang.mirrors.Routine {
@@ -122,7 +122,7 @@ public class lang.mirrors.Parameters extends lang.Object implements php.Iterator
   public lang.mirrors.Parameter named(string $name) throws lang.ElementNotFoundException
   public lang.mirrors.Parameter first() throws lang.ElementNotFoundException
   public lang.mirrors.Parameter at(int $position) throws lang.ElementNotFoundException
-  public php.Generator getIterator()
+  public iterable getIterator()
 }
 
 public class lang.mirrors.Parameter extends lang.Object {
@@ -153,9 +153,9 @@ public class lang.mirrors.Fields extends lang.Object implements php.IteratorAggr
 
   public bool provides(string $name)
   public lang.mirrors.Field named(string $name) throws lang.ElementNotFoundException
-  public php.Generator all([lang.mirrors.Predicates $filter= null])
-  public php.Generator declared([lang.mirrors.Predicates $filter= null])
-  public php.Generator getIterator()
+  public iterable all([lang.mirrors.Predicates $filter= null])
+  public iterable declared([lang.mirrors.Predicates $filter= null])
+  public iterable getIterator()
 }
 
 public class lang.mirrors.Field extends lang.mirrors.Member {
@@ -210,7 +210,7 @@ public class lang.mirrors.Constants extends lang.Object implements php.IteratorA
 
   public bool provides(string $name)
   public lang.mirrors.Constant named(string $name) throws lang.ElementNotFoundException
-  public php.Generator getIterator()
+  public iterable getIterator()
 }
 
 public class lang.mirrors.Constant extends lang.Object {
@@ -232,7 +232,7 @@ public class lang.mirrors.Annotations extends lang.Object implements php.Iterato
   public bool present()
   public bool provides(string $name)
   public lang.mirrors.Annotation named(string $name) throws lang.ElementNotFoundException
-  public php.Generator getIterator()
+  public iterable getIterator()
 }
 
 public class lang.mirrors.Annotation extends lang.Object {

--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,14 @@
   "description" : "Mirrors",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.10.2",
-    "xp-framework/tokenize": "^7.0 | ^6.6",
-    "xp-forge/parse": "^1.0",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.10.2",
+    "xp-framework/tokenize": "^8.0 | ^7.0 | ^6.6",
+    "xp-forge/parse": "^2.0 | ^1.0",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5",
-    "xp-forge/measure" : "^1.0"
-  },
-  "suggest" : {
-    "xp-framework/core": "^7.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5",
+    "xp-forge/measure" : "^2.0 | ^1.0"
   },
   "bin": ["bin/xp.xp-forge.mirrors.mirror"],
   "autoload" : {

--- a/src/main/php/lang/mirrors/Annotation.class.php
+++ b/src/main/php/lang/mirrors/Annotation.class.php
@@ -2,7 +2,7 @@
 
 use util\Objects;
 
-class Annotation extends \lang\Object {
+class Annotation {
   private $mirror, $name, $value;
 
   /**

--- a/src/main/php/lang/mirrors/Annotations.class.php
+++ b/src/main/php/lang/mirrors/Annotations.class.php
@@ -2,7 +2,9 @@
 
 use lang\ElementNotFoundException;
 
-class Annotations implements \IteratorAggregate {
+class Annotations implements \lang\Value, \IteratorAggregate {
+  use ListOf;
+
   private $mirror, $backing;
 
   /**
@@ -56,14 +58,5 @@ class Annotations implements \IteratorAggregate {
     foreach ($this->backing as $name => $value) {
       yield new Annotation($this->mirror, $name, $value);
     }
-  }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'('.\xp::stringOf($this->backing).')';
   }
 }

--- a/src/main/php/lang/mirrors/Annotations.class.php
+++ b/src/main/php/lang/mirrors/Annotations.class.php
@@ -2,7 +2,7 @@
 
 use lang\ElementNotFoundException;
 
-class Annotations extends \lang\Object implements \IteratorAggregate {
+class Annotations implements \IteratorAggregate {
   private $mirror, $backing;
 
   /**

--- a/src/main/php/lang/mirrors/Annotations.class.php
+++ b/src/main/php/lang/mirrors/Annotations.class.php
@@ -50,7 +50,7 @@ class Annotations extends \lang\Object implements \IteratorAggregate {
   /**
    * Iterates over all methods
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function getIterator() {
     foreach ($this->backing as $name => $value) {

--- a/src/main/php/lang/mirrors/Constant.class.php
+++ b/src/main/php/lang/mirrors/Constant.class.php
@@ -7,7 +7,7 @@ use util\Objects;
  *
  * @test   xp://lang.mirrors.unittest.ConstantTest
  */
-class Constant extends \lang\Object {
+class Constant {
   private $mirror, $name, $value;
 
   /**

--- a/src/main/php/lang/mirrors/Constants.class.php
+++ b/src/main/php/lang/mirrors/Constants.class.php
@@ -42,7 +42,7 @@ class Constants implements \lang\Value, \IteratorAggregate {
   /**
    * Iterates over all methods
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function getIterator() {
     foreach ($this->mirror->reflect->allConstants() as $name => $value) {

--- a/src/main/php/lang/mirrors/Constants.class.php
+++ b/src/main/php/lang/mirrors/Constants.class.php
@@ -2,7 +2,8 @@
 
 use lang\ElementNotFoundException;
 
-class Constants extends \lang\Object implements \IteratorAggregate {
+class Constants implements \lang\Value, \IteratorAggregate {
+  use ListOf;
   private $mirror;
 
   /**
@@ -47,18 +48,5 @@ class Constants extends \lang\Object implements \IteratorAggregate {
     foreach ($this->mirror->reflect->allConstants() as $name => $value) {
       yield new Constant($this->mirror, $name, $value);
     }
-  }
-
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    $s= nameof($this)."@[\n";
-    foreach ($this as $const) {
-      $s.= '  '.(string)$const."\n";
-    }
-    return $s.']';
   }
 }

--- a/src/main/php/lang/mirrors/Fields.class.php
+++ b/src/main/php/lang/mirrors/Fields.class.php
@@ -37,7 +37,7 @@ class Fields extends Members {
    * Iterates over fields.
    *
    * @param  util.Filter $filter
-   * @return php.Generator
+   * @return iterable
    */
   public function all($filter= null) {
     foreach ($this->mirror->reflect->allFields() as $name => $member) {
@@ -51,7 +51,7 @@ class Fields extends Members {
    * Iterates over declared fields.
    *
    * @param  util.Filter $filter
-   * @return php.Generator
+   * @return iterable
    */
   public function declared($filter= null) {
     foreach ($this->mirror->reflect->declaredFields() as $name => $member) {
@@ -66,7 +66,7 @@ class Fields extends Members {
    *
    * @deprecated Use all() or declared() instead
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
-   * @return php.Generator
+   * @return iterable
    */
   public function of($kind) {
     $instance= ($kind & Member::$STATIC) === 0;

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -35,7 +35,7 @@ class FromCode implements Source {
    *
    * @param  bool $parent Whether to include parents
    * @param  bool $traits Whether to include traits
-   * @return php.Generator
+   * @return iterable
    */
   private function merge($parent, $traits) {
     if ($parent && isset($this->decl['parent'])) {
@@ -132,7 +132,7 @@ class FromCode implements Source {
     return false;
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allInterfaces() {
     foreach ((array)$this->decl['implements'] as $interface) {
       $name= $this->resolve0($interface);
@@ -149,7 +149,7 @@ class FromCode implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredInterfaces() {
     foreach ((array)$this->decl['implements'] as $interface) {
       $name= $this->resolve0($interface);
@@ -157,7 +157,7 @@ class FromCode implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allTraits() {
     if (isset($this->decl['use'])) {
       foreach ($this->decl['use'] as $trait => $definition) {
@@ -172,7 +172,7 @@ class FromCode implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredTraits() {
     if (isset($this->decl['use'])) {
       foreach ($this->decl['use'] as $trait => $definition) {
@@ -294,7 +294,7 @@ class FromCode implements Source {
     throw new ElementNotFoundException('No field named $'.$name.' in '.$this->name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allFields() {
     if (isset($this->decl['field'])) {
       foreach ($this->decl['field'] as $name => $field) {
@@ -309,7 +309,7 @@ class FromCode implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredFields() {
     if (isset($this->decl['field'])) {
       foreach ($this->decl['field'] as $name => $field) {
@@ -419,7 +419,7 @@ class FromCode implements Source {
     throw new ElementNotFoundException('No method named '.$name.' in '.$this->name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allMethods() {
     if (isset($this->decl['method'])) {
       foreach ($this->decl['method'] as $name => $method) {
@@ -434,7 +434,7 @@ class FromCode implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredMethods() {
     if (isset($this->decl['method'])) {
       foreach ($this->decl['method'] as $name => $method) {
@@ -484,7 +484,7 @@ class FromCode implements Source {
     throw new ElementNotFoundException('No constant named '.$name.' in '.$this->name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allConstants() {
     if (isset($this->decl['const'])) {
       foreach ($this->decl['const'] as $name => $const) {

--- a/src/main/php/lang/mirrors/FromCode.class.php
+++ b/src/main/php/lang/mirrors/FromCode.class.php
@@ -9,7 +9,7 @@ use lang\ElementNotFoundException;
 use lang\IllegalArgumentException;
 use lang\IllegalStateException;
 
-class FromCode extends \lang\Object implements Source {
+class FromCode implements Source {
   private static $syntax;
   private $unit;
   protected $decl;
@@ -537,12 +537,18 @@ class FromCode extends \lang\Object implements Source {
   }
 
   /**
-   * Returns whether a given value is equal to this reflection source
+   * Compares a given value to this source
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof Source && $this->name === $cmp->name;
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->name, $value->name) : 1;
   }
+
+  /** @return string */
+  public function hashCode() { return 'R'.md5($this->name); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.$this->name.'>'; }
 }

--- a/src/main/php/lang/mirrors/FromIncomplete.class.php
+++ b/src/main/php/lang/mirrors/FromIncomplete.class.php
@@ -69,16 +69,16 @@ class FromIncomplete implements Source {
    */
   public function typeImplements($name) { return false; }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allInterfaces() { return []; }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredInterfaces() { return []; }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allTraits() { return []; }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredTraits() { return []; }
 
   /**
@@ -129,10 +129,10 @@ class FromIncomplete implements Source {
     throw new ElementNotFoundException('No field named $'.$name.' in '.$this->name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allFields() { return []; }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredFields() { return []; }
 
   /**
@@ -154,10 +154,10 @@ class FromIncomplete implements Source {
     throw new ElementNotFoundException('No method named '.$name.' in '.$this->name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allMethods() { return []; }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredMethods() { return []; }
 
   /**
@@ -179,7 +179,7 @@ class FromIncomplete implements Source {
     throw new ElementNotFoundException('No constant named '.$name.' in '.$this->name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allConstants() { return []; }
 
   /**

--- a/src/main/php/lang/mirrors/FromIncomplete.class.php
+++ b/src/main/php/lang/mirrors/FromIncomplete.class.php
@@ -7,7 +7,7 @@ use lang\XPClass;
 use lang\ElementNotFoundException;
 use lang\IllegalArgumentException;
 
-class FromIncomplete extends \lang\Object implements Source {
+class FromIncomplete implements Source {
   public $name;
 
   public function __construct($name) {
@@ -193,12 +193,19 @@ class FromIncomplete extends \lang\Object implements Source {
   }
 
   /**
-   * Returns whether a given value is equal to this reflection source
+   * Compares a given value to this source
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->name === $cmp->name;
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->name, $value->name) : 1;
   }
+
+  /** @return string */
+  public function hashCode() { return 'R'.md5($this->name); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.$this->name.'>'; }
+
 }

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -12,7 +12,7 @@ use lang\IllegalStateException;
 use lang\Throwable;
 use lang\Error;
 
-class FromReflection extends \lang\Object implements Source {
+class FromReflection implements Source {
   protected $reflect;
   private $source;
   private $unit= null;
@@ -611,12 +611,19 @@ class FromReflection extends \lang\Object implements Source {
   }
 
   /**
-   * Returns whether a given value is equal to this reflection source
+   * Compares a given value to this source
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof Source && $this->name === $cmp->name;
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->name, $value->name) : 1;
   }
+
+  /** @return string */
+  public function hashCode() { return 'R'.md5($this->name); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.$this->name.'>'; }
+
 }

--- a/src/main/php/lang/mirrors/FromReflection.class.php
+++ b/src/main/php/lang/mirrors/FromReflection.class.php
@@ -152,14 +152,14 @@ class FromReflection implements Source {
     return $this->reflect->implementsInterface($name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allInterfaces() {
     foreach ($this->reflect->getInterfaces() as $interface) {
       yield $interface->name => $this->source->reflect($interface);
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredInterfaces() {
     $parent= $this->reflect->getParentClass();
     $inherited= $parent ? array_flip($parent->getInterfaceNames()) : [];
@@ -173,7 +173,7 @@ class FromReflection implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allTraits() {
     $reflect= $this->reflect;
     do {
@@ -183,7 +183,7 @@ class FromReflection implements Source {
     } while ($reflect= $reflect->getParentClass());
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredTraits() {
     foreach ($this->reflect->getTraits() as $trait) {
       yield $trait->name => $this->source->reflect($trait);
@@ -376,14 +376,14 @@ class FromReflection implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allFields() {
     foreach ($this->reflect->getProperties() as $field) {
       yield $field->name => $this->field($field);
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredFields() {
     foreach ($this->reflect->getProperties() as $field) {
       if ($field->getDeclaringClass()->name === $this->reflect->name) {
@@ -538,14 +538,14 @@ class FromReflection implements Source {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allMethods() {
     foreach ($this->reflect->getMethods() as $method) {
       yield $method->name => $this->method($method);
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredMethods() {
     foreach ($this->reflect->getMethods() as $method) {
       if ($method->getDeclaringClass()->name === $this->reflect->name) {
@@ -576,7 +576,7 @@ class FromReflection implements Source {
     throw new ElementNotFoundException('No constant named '.$name.'() in '.$this->name);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allConstants() {
     foreach ($this->reflect->getConstants() as $name => $value) {
       yield $name => $value;

--- a/src/main/php/lang/mirrors/HackTypes.class.php
+++ b/src/main/php/lang/mirrors/HackTypes.class.php
@@ -13,7 +13,7 @@ use lang\FunctionType;
  * @see    http://docs.hhvm.com/manual/en/hack.annotations.php
  * @test   xp://lang.mirrors.unittest.HackTypesTest
  */
-class HackTypes extends \lang\Object {
+class HackTypes {
   private $reflect;
 
   /**

--- a/src/main/php/lang/mirrors/Interfaces.class.php
+++ b/src/main/php/lang/mirrors/Interfaces.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\mirrors;
 
-class Interfaces extends \lang\Object implements \IteratorAggregate {
+class Interfaces implements \IteratorAggregate {
   private $mirror;
 
   /**

--- a/src/main/php/lang/mirrors/Interfaces.class.php
+++ b/src/main/php/lang/mirrors/Interfaces.class.php
@@ -28,7 +28,7 @@ class Interfaces implements \IteratorAggregate {
   /**
    * Iterates over all interfaces
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function getIterator() {
     foreach ($this->mirror->reflect->allInterfaces() as $interface) {
@@ -39,7 +39,7 @@ class Interfaces implements \IteratorAggregate {
   /**
    * Returns only interfaces this type declares directly
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function declared() {
     foreach ($this->mirror->reflect->declaredInterfaces() as $interface) {

--- a/src/main/php/lang/mirrors/ListOf.class.php
+++ b/src/main/php/lang/mirrors/ListOf.class.php
@@ -22,10 +22,10 @@ trait ListOf {
 
   /** @return string */
   public function toString() {
-    $s= nameof($this)."@[\n";
+    $s= '';
     foreach ($this as $element) {
       $s.= '  '.str_replace("\n", "\n  ", $element->__toString())."\n";
     }
-    return $s.']';
+    return nameof($this).'@['.($s ? "\n".$s.']' : ']');
   }
 }

--- a/src/main/php/lang/mirrors/ListOf.class.php
+++ b/src/main/php/lang/mirrors/ListOf.class.php
@@ -1,0 +1,31 @@
+<?php namespace lang\mirrors;
+
+use util\Objects;
+
+trait ListOf {
+
+  /**
+   * Compares a given value to this list
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(iterator_to_array($this), iterator_to_array($value))
+      : 1
+    ;
+  }
+
+  /** @return string */
+  public function hashCode() { return 'L['.Objects::hashOf(iterator_to_array($this)); }
+
+  /** @return string */
+  public function toString() {
+    $s= nameof($this)."@[\n";
+    foreach ($this as $element) {
+      $s.= '  '.str_replace("\n", "\n  ", $element->__toString())."\n";
+    }
+    return $s.']';
+  }
+}

--- a/src/main/php/lang/mirrors/Member.class.php
+++ b/src/main/php/lang/mirrors/Member.class.php
@@ -2,11 +2,12 @@
 
 use lang\mirrors\parse\TagsSyntax;
 use lang\mirrors\parse\TagsSource;
+use util\Objects;
 
 /**
  * Base class for all type members: Fields, methods, constructors.
  */
-abstract class Member extends \lang\Object {
+abstract class Member implements \lang\Value {
   public static $STATIC= 0x0001, $INSTANCE= 0x0002, $DECLARED= 0x0004;  // Deprecated
   public $reflect;
   protected $mirror;
@@ -95,26 +96,26 @@ abstract class Member extends \lang\Object {
   public function annotation($named) { return $this->annotations()->named($named); }
 
   /**
-   * Returns whether a given value is equal to this member
+   * Compares a given value to this member
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && (
-      $this->reflect['name'] === $cmp->reflect['name'] &&
-      $this->reflect['holder'] === $cmp->reflect['holder']
-    );
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->reflect['name'], $this->reflect['holder']],
+        [$value->reflect['name'], $value->reflect['holder']]
+      )
+      : 1
+    ;
   }
 
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'('.$this.')';
-  }
+  /** @return string */
+  public function hashCode() { return 'M'.md5($this->__toString()); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'('.$this->__toString().')'; }
 
   /** @return string */
   public abstract function __toString();

--- a/src/main/php/lang/mirrors/Members.class.php
+++ b/src/main/php/lang/mirrors/Members.class.php
@@ -3,7 +3,9 @@
 /**
  * Base class for fields and methods
  */
-abstract class Members extends \lang\Object implements \IteratorAggregate {
+abstract class Members implements \lang\Value, \IteratorAggregate {
+  use ListOf;
+
   protected $mirror;
 
   /**
@@ -57,27 +59,15 @@ abstract class Members extends \lang\Object implements \IteratorAggregate {
    * Iterates over declared members.
    *
    * @param  util.Filter $filter
-   * @return php.Generator
+   * @return iterable
    */
   public abstract function declared($filter= null);
 
   /**
    * Iterates over all methods
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function getIterator() { return $this->all(); }
 
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    $s= nameof($this)."@[\n";
-    foreach ($this as $member) {
-      $s.= '  '.(string)$member."\n";
-    }
-    return $s.']';
-  }
 }

--- a/src/main/php/lang/mirrors/Members.class.php
+++ b/src/main/php/lang/mirrors/Members.class.php
@@ -51,7 +51,7 @@ abstract class Members implements \lang\Value, \IteratorAggregate {
    * Iterates over members.
    *
    * @param  util.Filter $filter
-   * @return php.Generator
+   * @return iterable
    */
   public abstract function all($filter= null);
 

--- a/src/main/php/lang/mirrors/Methods.class.php
+++ b/src/main/php/lang/mirrors/Methods.class.php
@@ -37,7 +37,7 @@ class Methods extends Members {
    * Iterates over methods.
    *
    * @param  util.Filter $filter
-   * @return php.Generator
+   * @return iterable
    */
   public function all($filter= null) {
     foreach ($this->mirror->reflect->allMethods() as $name => $member) {
@@ -51,7 +51,7 @@ class Methods extends Members {
    * Iterates over declared methods.
    *
    * @param  util.Filter $filter
-   * @return php.Generator
+   * @return iterable
    */
   public function declared($filter= null) {
     foreach ($this->mirror->reflect->declaredMethods() as $name => $member) {
@@ -66,7 +66,7 @@ class Methods extends Members {
    *
    * @deprecated Use all() or declared() instead
    * @param  int $kind Either Member::$STATIC or Member::$INSTANCE bitwise-or'ed with Member::$DECLARED
-   * @return php.Generator
+   * @return iterable
    */
   public function of($kind) {
     $instance= ($kind & Member::$STATIC) === 0;

--- a/src/main/php/lang/mirrors/Modifiers.class.php
+++ b/src/main/php/lang/mirrors/Modifiers.class.php
@@ -6,7 +6,7 @@
  * @test  xp://lang.mirrors.unittest.ModifiersTest
  * @see   https://github.com/xp-framework/xp-framework/wiki/codingstandards#modifiers
  */
-class Modifiers extends \lang\Object {
+class Modifiers implements \lang\Value {
   const IS_STATIC    = 0x0001;
   const IS_ABSTRACT  = 0x0002;
   const IS_FINAL     = 0x0004;
@@ -93,21 +93,23 @@ class Modifiers extends \lang\Object {
   public function isNative() { return 0 !== ($this->bits & self::IS_NATIVE); }
 
   /**
-   * Returns whether a given value is equal to this member
+   * Compares a given value to this modifiers instance
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->bits === $cmp->bits;
+  public function compareTo($value) {
+    if ($value instanceof self) {
+      $diff= $this->bits - $value->bits;
+      return $diff < 0 ? -1 : ($diff > 0 ? 1 : 0);
+    }
+    return 1;
   }
 
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'<'.$this->names().'>';
-  }
+  /** @return string */
+  public function hashCode() { return 'M['.$this->bits; }
+
+  /** @return string */
+  public function toString() { nameof($this).'<'.$this->names().'>'; }
+
 }

--- a/src/main/php/lang/mirrors/Package.class.php
+++ b/src/main/php/lang/mirrors/Package.class.php
@@ -5,7 +5,7 @@
  *
  * @test   xp://lang.mirrors.unittest.PackageTest
  */
-class Package extends \lang\Object {
+class Package implements \lang\Value {
   private $name;
   public static $GLOBAL;
 
@@ -32,21 +32,19 @@ class Package extends \lang\Object {
   public function isGlobal() { return '' === $this->name; }
 
   /**
-   * Returns whether a given value is equal to this code unit
+   * Compares a given value to this source
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->name === $cmp->name;
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->name, $value->name) : 1;
   }
 
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'<'.($this->isGlobal() ? '(global)' : $this->name).'>';
-  }
+  /** @return string */
+  public function hashCode() { return 'R'.md5($this->name); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.($this->isGlobal() ? '(global)' : $this->name).'>'; }
+
 }

--- a/src/main/php/lang/mirrors/Parameter.class.php
+++ b/src/main/php/lang/mirrors/Parameter.class.php
@@ -4,13 +4,14 @@ use lang\Type;
 use lang\IllegalArgumentException;
 use lang\IllegalStateException;
 use lang\mirrors\parse\VariadicTypeRef;
+use util\Objects;
 
 /**
  * A method or constructor parameter
  *
  * @test  xp://lang.mirrors.unittest.ParameterTest
  */
-class Parameter extends \lang\Object {
+class Parameter implements \lang\Value {
   private $mirror, $reflect;
 
   /**
@@ -96,26 +97,26 @@ class Parameter extends \lang\Object {
   }
 
   /**
-   * Returns whether a given value is equal to this parameter
+   * Compares a given value to this parameter
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && (
-      $this->mirror->equals($cmp->mirror) &&
-      $this->reflect['pos'] === $cmp->reflect['pos']
-    );
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->mirror, $this->reflect['pos']],
+        [$value->mirror, $value->reflect['pos']]
+      )
+      : 1
+    ;
   }
 
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'('.$this.')';
-  }
+  /** @return string */
+  public function hashCode() { return 'R'.md5($this->__toString()); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'('.$this->__toString().')'; }
 
   /** @return string */
   public function __toString() {

--- a/src/main/php/lang/mirrors/Parameters.class.php
+++ b/src/main/php/lang/mirrors/Parameters.class.php
@@ -108,7 +108,7 @@ class Parameters implements \IteratorAggregate {
   /**
    * Iterates over all parameters
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function getIterator() {
     foreach ($this->lookup()[self::BY_ID] as $param) {

--- a/src/main/php/lang/mirrors/Parameters.class.php
+++ b/src/main/php/lang/mirrors/Parameters.class.php
@@ -2,7 +2,7 @@
 
 use lang\ElementNotFoundException;
 
-class Parameters extends \lang\Object implements \IteratorAggregate {
+class Parameters implements \IteratorAggregate {
   const BY_ID = 0, BY_NAME = 1;
 
   private $mirror, $reflect;

--- a/src/main/php/lang/mirrors/Predicates.class.php
+++ b/src/main/php/lang/mirrors/Predicates.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\mirrors;
 
-class Predicates extends \lang\Object implements \util\Filter {
+class Predicates implements \util\Filter {
   private $filters= [];
 
   /**

--- a/src/main/php/lang/mirrors/Source.class.php
+++ b/src/main/php/lang/mirrors/Source.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\mirrors;
 
-interface Source {
+interface Source extends \lang\Value {
 
   /** @return bool */
   public function present();

--- a/src/main/php/lang/mirrors/Source.class.php
+++ b/src/main/php/lang/mirrors/Source.class.php
@@ -59,34 +59,34 @@ interface Source extends \lang\Value {
    */
   public function typeUses($name);
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredInterfaces();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allTraits();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredTraits();
 
   /** @return var */
   public function constructor();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allFields();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredFields();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allMethods();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function declaredMethods();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allConstants();
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function allInterfaces();
 
   /**

--- a/src/main/php/lang/mirrors/Throws.class.php
+++ b/src/main/php/lang/mirrors/Throws.class.php
@@ -1,6 +1,8 @@
 <?php namespace lang\mirrors;
 
-class Throws implements \IteratorAggregate {
+class Throws implements \lang\Value, \IteratorAggregate {
+  use ListOf;
+
   private $mirror, $tags;
 
   /**

--- a/src/main/php/lang/mirrors/Throws.class.php
+++ b/src/main/php/lang/mirrors/Throws.class.php
@@ -30,7 +30,7 @@ class Throws extends \lang\Object implements \IteratorAggregate {
   /**
    * Iterates over all interfaces
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function getIterator() {
     $type= $this->mirror->declaredIn();

--- a/src/main/php/lang/mirrors/Throws.class.php
+++ b/src/main/php/lang/mirrors/Throws.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\mirrors;
 
-class Throws extends \lang\Object implements \IteratorAggregate {
+class Throws implements \IteratorAggregate {
   private $mirror, $tags;
 
   /**

--- a/src/main/php/lang/mirrors/Traits.class.php
+++ b/src/main/php/lang/mirrors/Traits.class.php
@@ -1,6 +1,8 @@
 <?php namespace lang\mirrors;
 
-class Traits implements \IteratorAggregate {
+class Traits implements \lang\Value, \IteratorAggregate {
+  use ListOf;
+
   private $mirror;
 
   /**

--- a/src/main/php/lang/mirrors/Traits.class.php
+++ b/src/main/php/lang/mirrors/Traits.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\mirrors;
 
-class Traits extends \lang\Object implements \IteratorAggregate {
+class Traits implements \IteratorAggregate {
   private $mirror;
 
   /**

--- a/src/main/php/lang/mirrors/Traits.class.php
+++ b/src/main/php/lang/mirrors/Traits.class.php
@@ -28,7 +28,7 @@ class Traits extends \lang\Object implements \IteratorAggregate {
   /**
    * Iterates over all traits
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function getIterator() {
     foreach ($this->mirror->reflect->allTraits() as $trait) {
@@ -40,7 +40,7 @@ class Traits extends \lang\Object implements \IteratorAggregate {
   /**
    * Returns only traits this type uses directly
    *
-   * @return php.Generator
+   * @return iterable
    */
   public function declared() {
     foreach ($this->mirror->reflect->declaredTraits() as $trait) {

--- a/src/main/php/lang/mirrors/TypeMirror.class.php
+++ b/src/main/php/lang/mirrors/TypeMirror.class.php
@@ -16,7 +16,7 @@ use lang\IllegalArgumentException;
  * @test   xp://lang.mirrors.unittest.TypeMirrorTest
  * @test   xp://lang.mirrors.unittest.TypeMirrorTraitsTest
  */
-class TypeMirror extends \lang\Object {
+class TypeMirror implements \lang\Value {
   private $methods= null;
   private $fields= null;
   private $annotations= null;
@@ -148,21 +148,18 @@ class TypeMirror extends \lang\Object {
   }
 
   /**
-   * Returns whether a given value is equal to this type mirror
+   * Compares a given value to this type mirror
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->reflect->equals($cmp->reflect);
+  public function compareTo($value) {
+    return $value instanceof self ? $this->reflect->compareTo($value->reflect) : 1;
   }
 
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
-  public function toString() {
-    return nameof($this).'<'.$this->name().'>';
-  }
+  /** @return string */
+  public function hashCode() { return 'M'.md5($this->name()); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.$this->name().'>'; }
 }

--- a/src/main/php/lang/mirrors/parse/ArrayExpr.class.php
+++ b/src/main/php/lang/mirrors/parse/ArrayExpr.class.php
@@ -7,7 +7,7 @@ use util\Objects;
  *
  * @test  xp://lang.mirrors.unittest.ArrayExprTest
  */
-class ArrayExpr extends \lang\Object {
+class ArrayExpr {
   private $backing;
 
   public function __construct($value) {

--- a/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
+++ b/src/main/php/lang/mirrors/parse/ClassSyntax.class.php
@@ -5,7 +5,7 @@ use lang\XPClass;
 /**
  * Fetches code unit for a given class. Supports PHP and Hack syntax.
  */
-class ClassSyntax extends \lang\Object {
+class ClassSyntax {
   const CACHE_LIMIT = 20;
   private static $cache= [];
   private static $syntax;

--- a/src/main/php/lang/mirrors/parse/Closure.class.php
+++ b/src/main/php/lang/mirrors/parse/Closure.class.php
@@ -3,7 +3,7 @@
 use util\Objects;
 use lang\IllegalStateException;
 
-class Closure extends \lang\Object {
+class Closure {
   private $params, $code;
 
   public function __construct($params, $code) {

--- a/src/main/php/lang/mirrors/parse/CodeUnit.class.php
+++ b/src/main/php/lang/mirrors/parse/CodeUnit.class.php
@@ -2,7 +2,7 @@
 
 use util\Objects;
 
-class CodeUnit extends \lang\Object {
+class CodeUnit {
   private $package, $imports;
 
   /**

--- a/src/main/php/lang/mirrors/parse/Constant.class.php
+++ b/src/main/php/lang/mirrors/parse/Constant.class.php
@@ -28,13 +28,13 @@ class Constant extends Resolveable {
   }
 
   /**
-   * Returns whether a given value is equal to this code unit
+   * Compares a given value to this list
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->name === $cmp->name;
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->name, $value->name) : 1;
   }
 
   /** @return string */

--- a/src/main/php/lang/mirrors/parse/Resolveable.class.php
+++ b/src/main/php/lang/mirrors/parse/Resolveable.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\mirrors\parse;
 
-abstract class Resolveable extends \lang\Object {
+abstract class Resolveable implements \lang\Value {
 
   /**
    * Resolve this value 
@@ -11,13 +11,20 @@ abstract class Resolveable extends \lang\Object {
   public abstract function resolve($source);
 
   /**
-   * Creates a string representation
+   * Compares a given value to this list
    *
-   * @return string
+   * @param  var $value
+   * @return int
    */
-  public function toString() {
-    return nameof($this).'<'.$this.'>';
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->__toString(), $value->__toString()) : 1;
   }
+
+  /** @return string */
+  public function hashCode() { return '*'.md5($this->__toString()); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.$this->__toString().'>'; }
 
   /** @return string */
   public abstract function __toString();

--- a/src/main/php/xp/mirrors/ClassInformation.class.php
+++ b/src/main/php/xp/mirrors/ClassInformation.class.php
@@ -1,6 +1,7 @@
 <?php namespace xp\mirrors;
 
 use lang\mirrors\TypeMirror;
+use lang\mirrors\Fields;
 use lang\mirrors\Methods;
 
 class ClassInformation extends TypeKindInformation {
@@ -19,15 +20,15 @@ class ClassInformation extends TypeKindInformation {
     $separator= false;
     $out->writeLine(' {');
     $this->displayMembers($this->mirror->constants(), $out, $separator);
-    $this->displayMembers($this->mirror->fields()->declared(), $out, $separator);
+    $this->displayMembers($this->mirror->fields()->declared(Fields::with($this->visibility)), $out, $separator);
     $constructor= $this->mirror->constructor();
     if ($constructor->present()) {
       $this->displayMembers([$constructor], $out, $separator);
     } else {
       $separator= false;
     }
-    $this->displayMembers($this->mirror->methods()->all(Methods::ofClass()), $out, $separator);
-    $this->displayMembers($this->mirror->methods()->all(Methods::ofInstance()), $out, $separator);
+    $this->displayMembers($this->mirror->methods()->all(Methods::ofClass()->with($this->visibility)), $out, $separator);
+    $this->displayMembers($this->mirror->methods()->all(Methods::ofInstance()->with($this->visibility)), $out, $separator);
     $out->writeLine('}');
   }
 }

--- a/src/main/php/xp/mirrors/DirectoryInformation.class.php
+++ b/src/main/php/xp/mirrors/DirectoryInformation.class.php
@@ -30,7 +30,7 @@ class DirectoryInformation extends CollectionInformation {
     throw new IllegalArgumentException('Cannot find '.$uri.' in class path');
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function sources() {
     yield $this->loader;
   }

--- a/src/main/php/xp/mirrors/EnumInformation.class.php
+++ b/src/main/php/xp/mirrors/EnumInformation.class.php
@@ -2,6 +2,7 @@
 
 use lang\mirrors\TypeMirror;
 use lang\mirrors\Methods;
+use lang\mirrors\Fields;
 use lang\Enum;
 
 class EnumInformation extends TypeKindInformation {
@@ -29,7 +30,7 @@ class EnumInformation extends TypeKindInformation {
       $mirror= new TypeMirror(typeof($member));
       if ($mirror->isSubtypeOf($this->mirror)) {
         $out->writeLine(' {');
-        foreach ($mirror->methods()->declared() as $method) {
+        foreach ($mirror->methods()->declared(Methods::with($this->visibility)) as $method) {
           $out->writeLine('    ', (string)$method);
         }
         $separator= true;
@@ -44,8 +45,8 @@ class EnumInformation extends TypeKindInformation {
     if ($constructor->present()) {
       $this->displayMembers([$constructor], $out, $separator);
     }
-    $this->displayMembers($this->mirror->methods()->all(Methods::ofClass()), $out, $separator);
-    $this->displayMembers($this->mirror->methods()->all(Methods::ofInstance()), $out, $separator);
+    $this->displayMembers($this->mirror->methods()->all(Methods::ofClass()->with($this->visibility)), $out, $separator);
+    $this->displayMembers($this->mirror->methods()->all(Methods::ofInstance()->with($this->visibility)), $out, $separator);
     $out->writeLine('}');
   }
 }

--- a/src/main/php/xp/mirrors/Information.class.php
+++ b/src/main/php/xp/mirrors/Information.class.php
@@ -21,7 +21,7 @@ abstract class Information {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public abstract function sources();
 
   /**

--- a/src/main/php/xp/mirrors/MirrorRunner.class.php
+++ b/src/main/php/xp/mirrors/MirrorRunner.class.php
@@ -12,6 +12,10 @@ use lang\IllegalArgumentException;
  *   ```sh
  *   $ xp mirror lang.Value
  *   ```
+ * - Include non-public members
+ *   ```sh
+ *   $ xp mirror lang.CommandLine --all
+ *   ```
  * - Show information about a file declaring a type
  *   ```sh
  *   $ xp mirror src/main/php/Example.class.php

--- a/src/main/php/xp/mirrors/MirrorRunner.class.php
+++ b/src/main/php/xp/mirrors/MirrorRunner.class.php
@@ -48,7 +48,7 @@ class MirrorRunner {
       } else if (is_dir($name)) {
         $info= new DirectoryInformation($name);
       } else if ($cl->providesClass($name)) {
-        $info= new TypeInformation($cl->loadClass($name));
+        $info= new TypeInformation($cl->loadClass($name), in_array('--all', $args));
       } else if ($cl->providesPackage($name)) {
         $info= new PackageInformation($name);
       } else {

--- a/src/main/php/xp/mirrors/PackageInformation.class.php
+++ b/src/main/php/xp/mirrors/PackageInformation.class.php
@@ -15,7 +15,7 @@ class PackageInformation extends CollectionInformation {
     $this->package= $package instanceof Package ? $package : new Package(rtrim($package, '.'));
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function sources() {
     $name= $this->package->name();
     foreach (ClassLoader::getLoaders() as $loader) {

--- a/src/main/php/xp/mirrors/TraitInformation.class.php
+++ b/src/main/php/xp/mirrors/TraitInformation.class.php
@@ -1,5 +1,8 @@
 <?php namespace xp\mirrors;
 
+use lang\mirrors\Fields;
+use lang\mirrors\Methods;
+
 class TraitInformation extends TypeKindInformation {
 
   /**
@@ -12,12 +15,12 @@ class TraitInformation extends TypeKindInformation {
     $separator= false;
     $out->write(self::declarationOf($this->mirror), ' {');
     $this->displayMembers($this->mirror->constants(), $out, $separator);
-    $this->displayMembers($this->mirror->fields(), $out, $separator);
+    $this->displayMembers($this->mirror->fields()->all(Fields::with($this->visibility)), $out, $separator);
     $constructor= $this->mirror->constructor();
     if ($constructor->present()) {
       $this->displayMembers([$constructor], $out, $separator);
     }
-    $this->displayMembers($this->mirror->methods(), $out, $separator);
+    $this->displayMembers($this->mirror->methods()->all(Methods::with($this->visibility)), $out, $separator);
     $out->writeLine('}');
   }
 }

--- a/src/main/php/xp/mirrors/TypeInformation.class.php
+++ b/src/main/php/xp/mirrors/TypeInformation.class.php
@@ -10,18 +10,19 @@ class TypeInformation extends Information {
    * Creates a new type information instance
    *
    * @param  lang.mirrors.TypeMirror|lang.XPClass $arg
+   * @param  bool $all Whether to display all members, defaults to false
    */
-  public function __construct($arg) {
+  public function __construct($arg, $all= false) {
     $mirror= $arg instanceof TypeMirror ? $arg : new TypeMirror($arg);
     $kind= $mirror->kind();
     if ($kind->isEnum()) {
-      $this->delegate= new EnumInformation($mirror);
+      $this->delegate= new EnumInformation($mirror, $all);
     } else if ($kind->isTrait()) {
-      $this->delegate= new TraitInformation($mirror);
+      $this->delegate= new TraitInformation($mirror, $all);
     } else if ($kind->isInterface()) {
-      $this->delegate= new InterfaceInformation($mirror);
+      $this->delegate= new InterfaceInformation($mirror, $all);
     } else if ($kind->isClass()) {
-      $this->delegate= new ClassInformation($mirror);
+      $this->delegate= new ClassInformation($mirror, $all);
     } else {
       throw new IllegalStateException('Unknown type kind '.$kind->toString());
     }

--- a/src/main/php/xp/mirrors/TypeInformation.class.php
+++ b/src/main/php/xp/mirrors/TypeInformation.class.php
@@ -27,7 +27,7 @@ class TypeInformation extends Information {
     }
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function sources() {
     foreach ($this->delegate->sources() as $source) {
       yield $source;

--- a/src/main/php/xp/mirrors/TypeKindInformation.class.php
+++ b/src/main/php/xp/mirrors/TypeKindInformation.class.php
@@ -15,15 +15,15 @@ abstract class TypeKindInformation extends Information {
     $this->mirror= $arg instanceof TypeMirror ? $arg : new TypeMirror($arg);
   }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function sources() { yield ClassLoader::getDefault()->findClass($this->mirror->name()); }
 
   /**
    * Display type extensions
    *
-   * @param  php.Generator $types
+   * @param  iterable $types
    * @param  io.StringWriter $out
-   * @param  string $kinde
+   * @param  string $kind
    * @return void
    */
   protected function displayExtensions($types, $out, $kind) {
@@ -39,7 +39,7 @@ abstract class TypeKindInformation extends Information {
   /**
    * Display members
    *
-   * @param  php.Generator $members
+   * @param  iterable $members
    * @param  io.StringWriter $out
    * @param  bool $separator
    * @return void

--- a/src/main/php/xp/mirrors/TypeKindInformation.class.php
+++ b/src/main/php/xp/mirrors/TypeKindInformation.class.php
@@ -4,15 +4,20 @@ use lang\mirrors\TypeMirror;
 use lang\ClassLoader;
 
 abstract class TypeKindInformation extends Information {
-  protected $mirror;
+  protected $mirror, $visibility;
 
   /**
    * Creates a new type information instance
    *
    * @param  lang.mirrors.TypeMirror|lang.XPClass $arg
+   * @param  bool all Whether to incude all members - defaults: No
    */
-  public function __construct($arg) {
+  public function __construct($arg, $all= false) {
     $this->mirror= $arg instanceof TypeMirror ? $arg : new TypeMirror($arg);
+    $this->visibility= $all
+      ? function($member) { return true; }
+      : function($member) { return $member->modifiers()->isPublic(); }
+    ;
   }
 
   /** @return iterable */

--- a/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackAnnotations.class.php
+++ b/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackAnnotations.class.php
@@ -9,7 +9,7 @@
  * @see    https://github.com/facebook/hhvm/issues/3605
  */
 <<test, runtime('~3.6'), expect(['class' => 'lang.IllegalArgumentException'])>>
-class FixtureHackAnnotations extends \lang\Object {
+class FixtureHackAnnotations {
 
   #[@test, @runtime('~3.6'), @expect(class = 'lang.IllegalArgumentException')]
   public $field;

--- a/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackBaseClass.class.php
+++ b/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackBaseClass.class.php
@@ -1,0 +1,5 @@
+<?hh namespace lang\mirrors\unittest\fixture;
+
+/** Used by FixtureHackTypedClass */
+class FixtureHackBaseClass {
+}

--- a/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackCapClass.class.php
+++ b/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackCapClass.class.php
@@ -5,7 +5,7 @@
  *
  * @see    http://docs.hhvm.com/manual/en/hack.constructorargumentpromotion.php
  */
-class FixtureHackCapClass extends \lang\Object {
+class FixtureHackCapClass {
 
   public function __construct(
     public string $name,

--- a/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackTypedClass.class.php
+++ b/src/test/hack/lang/mirrors/unittest/fixture/FixtureHackTypedClass.class.php
@@ -9,7 +9,7 @@
  * @see    http://docs.hhvm.com/manual/en/hack.annotations.functiontypes.php
  * @see    http://docs.hhvm.com/manual/en/hack.nullable.php
  */
-class FixtureHackTypedClass extends \lang\Object {
+class FixtureHackTypedClass extends FixtureHackBaseClass {
   public int $typed;
   public parent $parentTyped;
   public this $thisTyped;

--- a/src/test/php/lang/mirrors/unittest/ConstructorTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ConstructorTest.class.php
@@ -5,6 +5,7 @@ use lang\mirrors\TypeMirror;
 use lang\mirrors\Modifiers;
 use lang\IllegalArgumentException;
 use lang\mirrors\TargetInvocationException;
+use lang\mirrors\unittest\fixture\FixtureBase;
 use lang\mirrors\unittest\fixture\FixtureInterface;
 use lang\mirrors\unittest\fixture\FixtureTrait;
 use lang\mirrors\unittest\fixture\FixtureAbstract;
@@ -33,28 +34,28 @@ class ConstructorTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function object_classes_constructor_has_no_params() {
-    $type= new TypeMirror(Object::class);
+  public function base_classes_constructor_has_no_params() {
+    $type= new TypeMirror(FixtureBase::class);
     $this->assertEquals(0, (new Constructor($type))->parameters()->length());
   }
 
   #[@test]
-  public function object_classes_constructor_is_public() {
-    $type= new TypeMirror(Object::class);
+  public function base_classes_constructor_is_public() {
+    $type= new TypeMirror(FixtureBase::class);
     $this->assertEquals(new Modifiers('public'), (new Constructor($type))->modifiers());
   }
 
   #[@test]
   public function creating_new_object_instances() {
     $this->assertInstanceOf(
-      Object::class,
-      (new Constructor(new TypeMirror(Object::class)))->newInstance()
+      FixtureBase::class,
+      (new Constructor(new TypeMirror(FixtureBase::class)))->newInstance()
     );
   }
 
   #[@test]
   public function creating_instances_invokes_constructor() {
-    $fixture= newinstance(Object::class, [], '{
+    $fixture= newinstance(FixtureBase::class, [], '{
       public $passed= null;
       public function __construct(... $args) { $this->passed= $args; }
     }');
@@ -66,7 +67,7 @@ class ConstructorTest extends \unittest\TestCase {
 
   #[@test, @expect(TargetInvocationException::class)]
   public function creating_instances_wraps_exceptions() {
-    $fixture= ClassLoader::defineClass($this->name, Object::class, [], [
+    $fixture= ClassLoader::defineClass($this->name, FixtureBase::class, [], [
       '__construct' => function($arg) { throw new IllegalArgumentException('Test'); }
     ]);
     (new Constructor(new TypeMirror($fixture)))->newInstance(null);
@@ -74,7 +75,7 @@ class ConstructorTest extends \unittest\TestCase {
 
   #[@test, @expect(TargetInvocationException::class)]
   public function creating_instances_wraps_argument_mismatch_exceptions() {
-    $fixture= ClassLoader::defineClass($this->name, Object::class, [], [
+    $fixture= ClassLoader::defineClass($this->name, FixtureBase::class, [], [
       '__construct' => function(TypeMirror $arg) { }
     ]);
     (new Constructor(new TypeMirror($fixture)))->newInstance(null);
@@ -82,7 +83,7 @@ class ConstructorTest extends \unittest\TestCase {
 
   #[@test, @expect(TargetInvocationException::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function creating_instances_wraps_errors() {
-    $fixture= ClassLoader::defineClass($this->name, Object::class, [], [
+    $fixture= ClassLoader::defineClass($this->name, FixtureBase::class, [], [
       '__construct' => function($arg) { $arg->invoke(); }
     ]);
     (new Constructor(new TypeMirror($fixture)))->newInstance(null);
@@ -91,7 +92,7 @@ class ConstructorTest extends \unittest\TestCase {
   #[@test]
   public function sets_cause_for_exceptions_thrown() {
     try {
-      $fixture= ClassLoader::defineClass($this->name, Object::class, [], [
+      $fixture= ClassLoader::defineClass($this->name, FixtureBase::class, [], [
         '__construct' => function($arg) { throw new IllegalArgumentException('Test'); }
       ]);
       (new Constructor(new TypeMirror($fixture)))->newInstance(null);
@@ -104,7 +105,7 @@ class ConstructorTest extends \unittest\TestCase {
   #[@test, @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function sets_cause_for_errors_raised() {
     try {
-      $fixture= ClassLoader::defineClass($this->name, Object::class, [], [
+      $fixture= ClassLoader::defineClass($this->name, FixtureBase::class, [], [
         '__construct' => function($arg) { $arg->invoke(); }
       ]);
       (new Constructor(new TypeMirror($fixture)))->newInstance(null);

--- a/src/test/php/lang/mirrors/unittest/HackTypingTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/HackTypingTest.class.php
@@ -9,6 +9,7 @@ use lang\FunctionType;
 use lang\XPClass;
 use lang\mirrors\TypeMirror;
 use lang\mirrors\unittest\fixture\FixtureHackTypedClass;
+use lang\mirrors\unittest\fixture\FixtureHackBaseClass;
 
 abstract class HackTypingTest extends \unittest\TestCase {
 
@@ -32,7 +33,7 @@ abstract class HackTypingTest extends \unittest\TestCase {
 
   #[@test, @values(source= 'targets', args= ['parentTyped'])]
   public function parent_typed($target) {
-    $this->assertEquals(new XPClass(Object::class), $target);
+    $this->assertEquals(new XPClass(FixtureHackBaseClass::class), $target);
   }
 
   #[@test, @values(source= 'targets', args= ['thisTyped'])]

--- a/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/MethodReturnTypeTest.class.php
@@ -52,12 +52,12 @@ class MethodReturnTypeTest extends AbstractMethodTest {
 
   #[@test]
   public function self_supported() {
-    $this->assertEquals($this->getClass(), $this->fixture('selfFixture')->returns());
+    $this->assertEquals(typeof($this), $this->fixture('selfFixture')->returns());
   }
 
   #[@test]
   public function parent_supported() {
-    $this->assertEquals($this->getClass()->getParentclass(), $this->fixture('parentFixture')->returns());
+    $this->assertEquals(typeof($this)->getParentclass(), $this->fixture('parentFixture')->returns());
   }
 
   #[@test]

--- a/src/test/php/lang/mirrors/unittest/ModifiersTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/ModifiersTest.class.php
@@ -109,16 +109,16 @@ class ModifiersTest extends AbstractMethodTest {
   #[@test]
   public function equals_itself() {
     $modifiers= new Modifiers(Modifiers::IS_PUBLIC);
-    $this->assertTrue($modifiers->equals($modifiers));
+    $this->assertEquals($modifiers, $modifiers);
   }
 
   #[@test]
   public function equals_other_instance_with_same_bits() {
-    $this->assertTrue((new Modifiers(Modifiers::IS_PUBLIC))->equals(new Modifiers(Modifiers::IS_PUBLIC)));
+    $this->assertEquals(new Modifiers(Modifiers::IS_PUBLIC), new Modifiers(Modifiers::IS_PUBLIC));
   }
 
   #[@test]
   public function does_not_equal_instance_with_differing_bits() {
-    $this->assertFalse((new Modifiers(Modifiers::IS_PUBLIC))->equals(new Modifiers(Modifiers::IS_PROTECTED)));
+    $this->assertNotEquals(new Modifiers(Modifiers::IS_PUBLIC), new Modifiers(Modifiers::IS_PROTECTED));
   }
 }

--- a/src/test/php/lang/mirrors/unittest/NotOnHHVM.class.php
+++ b/src/test/php/lang/mirrors/unittest/NotOnHHVM.class.php
@@ -2,7 +2,7 @@
 
 use unittest\TestCase;
 
-class NotOnHHVM extends \lang\Object implements \unittest\TestAction {
+class NotOnHHVM implements \unittest\TestAction {
 
   /**
    * Returns whether we're running on HHVM runtime

--- a/src/test/php/lang/mirrors/unittest/OnlyOnHHVM.class.php
+++ b/src/test/php/lang/mirrors/unittest/OnlyOnHHVM.class.php
@@ -4,7 +4,7 @@ use lang\XPClass;
 use unittest\TestCase;
 use unittest\PrerequisitesNotMetError;
 
-class OnlyOnHHVM extends \lang\Object implements \unittest\TestAction, \unittest\TestClassAction {
+class OnlyOnHHVM implements \unittest\TestAction, \unittest\TestClassAction {
 
   /**
    * Verifies HHVM

--- a/src/test/php/lang/mirrors/unittest/Php7TypesTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/Php7TypesTest.class.php
@@ -5,6 +5,7 @@ use lang\Type;
 use lang\XPClass;
 use lang\mirrors\TypeMirror;
 use unittest\actions\RuntimeVersion;
+use lang\mirrors\unittest\fixture\FixtureBase;
 
 abstract class Php7TypesTest extends \unittest\TestCase {
   use TypeDefinition;
@@ -55,20 +56,21 @@ abstract class Php7TypesTest extends \unittest\TestCase {
 
   #[@test]
   public function parent_return_type() {
-    $fixture= $this->define('{
-      public function fixture(): parent { return new parent(); }
-    }');
+    $fixture= $this->define(
+      '{ public function fixture(): parent { return new parent(); } }',
+      [FixtureBase::class]
+    );
 
-    $this->assertEquals(XPClass::forName('lang.Object'), $this->newFixture($fixture)->methods()->named('fixture')->returns());
+    $this->assertEquals(new XPClass(FixtureBase::class), $this->newFixture($fixture)->methods()->named('fixture')->returns());
   }
 
   #[@test]
-  public function object_return_type() {
+  public function value_return_type() {
     $fixture= $this->define('{
-      public function fixture(): \lang\Object { return new \lang\Object(); }
+      public function fixture(): \lang\Value { /* TBI */ }
     }');
 
-    $this->assertEquals(XPClass::forName('lang.Object'), $this->newFixture($fixture)->methods()->named('fixture')->returns());
+    $this->assertEquals(XPClass::forName('lang.Value'), $this->newFixture($fixture)->methods()->named('fixture')->returns());
   }
 
   #[@test, @action(new RuntimeVersion('>=7.1.0-dev'))]

--- a/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeDefinition.class.php
@@ -19,7 +19,7 @@ trait TypeDefinition {
    * @param  string[] $extends
    * @return lang.XPClass
    */
-  protected function define($declaration, $extends= [Object::class]) {
+  protected function define($declaration, $extends= null) {
     if (!isset(self::$fixtures[$declaration])) {
       $definition= [
         'kind'       => 'class',
@@ -44,7 +44,7 @@ trait TypeDefinition {
    * @param  string[] $extends
    * @return lang.mirrors.TypeMirror
    */
-  protected function mirror($body, $extends= [Object::class]) {
+  protected function mirror($body, $extends= null) {
     return new TypeMirror($this->define($body, $extends), $this->source());
   }
 }

--- a/src/test/php/lang/mirrors/unittest/TypeMirrorInterfacesTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/TypeMirrorInterfacesTest.class.php
@@ -1,14 +1,15 @@
 <?php namespace lang\mirrors\unittest;
 
 use lang\mirrors\TypeMirror;
-use lang\Generic;
+use lang\Closeable;
 use lang\mirrors\unittest\fixture\FixtureInterface;
+use lang\mirrors\unittest\fixture\FixtureBase;
 
-class TypeMirrorInterfacesTest extends \unittest\TestCase implements FixtureInterface {
+class TypeMirrorInterfacesTest extends \unittest\TestCase {
   private $fixture;
 
   public function setUp() {
-    $this->fixture= new TypeMirror(self::class);
+    $this->fixture= new TypeMirror(FixtureBase::class);
   }
 
   #[@test]
@@ -28,11 +29,9 @@ class TypeMirrorInterfacesTest extends \unittest\TestCase implements FixtureInte
 
   #[@test]
   public function all_interfaces() {
-    $interfaces= iterator_to_array($this->fixture->interfaces());
-    usort($interfaces, function($a, $b) { return strcmp($a->name(), $b->name()); });
     $this->assertEquals(
-      [new TypeMirror(Generic::class), new TypeMirror(FixtureInterface::class)],
-      $interfaces
+      [new TypeMirror(FixtureInterface::class)],
+      iterator_to_array($this->fixture->interfaces())
     );
   }
 

--- a/src/test/php/lang/mirrors/unittest/fixture/FixtureAbstract.class.php
+++ b/src/test/php/lang/mirrors/unittest/fixture/FixtureAbstract.class.php
@@ -1,4 +1,4 @@
 <?php namespace lang\mirrors\unittest\fixture;
 
-abstract class FixtureAbstract extends \lang\Object {
+abstract class FixtureAbstract {
 }

--- a/src/test/php/lang/mirrors/unittest/fixture/FixtureFinal.class.php
+++ b/src/test/php/lang/mirrors/unittest/fixture/FixtureFinal.class.php
@@ -1,4 +1,4 @@
 <?php namespace lang\mirrors\unittest\fixture;
 
-final class FixtureFinal extends \lang\Object {
+final class FixtureFinal {
 }

--- a/src/test/php/lang/mirrors/unittest/fixture/FixtureParams.class.php
+++ b/src/test/php/lang/mirrors/unittest/fixture/FixtureParams.class.php
@@ -2,7 +2,7 @@
 
 use lang\Type;
 
-class FixtureParams extends \lang\Object {
+class FixtureParams {
   const CONSTANT = 'Test';
 
   private function noParam() { }

--- a/src/test/php/lang/mirrors/unittest/fixture/Identity.class.php
+++ b/src/test/php/lang/mirrors/unittest/fixture/Identity.class.php
@@ -2,7 +2,7 @@
 
 use util\Objects;
 
-final class Identity extends \lang\Object {
+final class Identity implements \lang\Value {
   const NAME = 'Id';
   public static $NULL;
   private $value;
@@ -11,8 +11,22 @@ final class Identity extends \lang\Object {
     self::$NULL= new self(null);
   }
 
-  /** @param  var $value */
+  /** @param var $value */
   public function __construct($value) { $this->value= $value; }
 
-  public function equals($cmp) { return $cmp instanceof self && Objects::equal($this->value, $cmp->value); }
+  /** @return string */
+  public function toString() { return nameof($this).'('.Objects::stringOf($this->value).')'; }
+
+  /** @return string */
+  public function hashCode() { return '@'.Objects::hashOf($this->value); }
+
+  /**
+   * Compares this identity to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->value, $value->value) : 1;
+  }
 }

--- a/src/test/php/lang/mirrors/unittest/parse/NewInstanceTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/NewInstanceTest.class.php
@@ -1,22 +1,22 @@
 <?php namespace lang\mirrors\unittest\parse;
 
-use lang\Object;
 use lang\mirrors\parse\NewInstance;
 use lang\mirrors\parse\Value;
+use lang\mirrors\unittest\fixture\FixtureBase;
 
 class NewInstanceTest extends ResolveableTest {
 
   #[@test]
   public function resolved() {
     $this->assertInstanceOf(
-      Object::class,
-      (new NewInstance('lang.Object', []))->resolve($this->source)
+      FixtureBase::class,
+      (new NewInstance('lang.mirrors.unittest.fixture.FixtureBase', []))->resolve($this->source)
     );
   }
 
   #[@test]
   public function passes_args_to_constructor() {
-    $fixture= newinstance(Object::class, [], '{
+    $fixture= newinstance(FixtureBase::class, [], '{
       public $passed= null;
       public function __construct(... $args) { $this->passed= $args; }
     }');

--- a/src/test/php/lang/mirrors/unittest/parse/ReferenceTypeRefTest.class.php
+++ b/src/test/php/lang/mirrors/unittest/parse/ReferenceTypeRefTest.class.php
@@ -8,7 +8,7 @@ class ReferenceTypeRefTest extends ResolveableTest {
   #[@test]
   public function fully_qualified_class_name() {
     $this->assertEquals(
-      $this->getClass(),
+      typeof($this),
       (new ReferenceTypeRef('\\'.__CLASS__))->resolve($this->source)
     );
   }
@@ -32,7 +32,7 @@ class ReferenceTypeRefTest extends ResolveableTest {
   #[@test]
   public function unqualified_class_name_with_same_name_as_this_class() {
     $this->assertEquals(
-      $this->getClass(),
+      typeof($this),
       (new ReferenceTypeRef('ReferenceTypeRefTest'))->resolve($this->source)
     );
   }
@@ -40,7 +40,7 @@ class ReferenceTypeRefTest extends ResolveableTest {
   #[@test]
   public function self_keyword() {
     $this->assertEquals(
-      $this->getClass(),
+      typeof($this),
       (new ReferenceTypeRef('self'))->resolve($this->source)
     );
   }
@@ -48,7 +48,7 @@ class ReferenceTypeRefTest extends ResolveableTest {
   #[@test]
   public function parent_keyword() {
     $this->assertEquals(
-      $this->getClass()->getParentclass(),
+      typeof($this)->getParentclass(),
       (new ReferenceTypeRef('parent'))->resolve($this->source)
     );
   }


### PR DESCRIPTION
This pull request adds compatibility with XP9 by:

* Implementing `lang.Value` instead of extending `lang.Object`
* Replacing calls to `$instance->getClass()` with `typeof($instance)`
* Changing tests relying on parent class being lang.Object with dedicated parent class fixtures
* Using the `iterable` type hint